### PR TITLE
feat(auth-service): add handler for FeignException

### DIFF
--- a/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ApplicationMessages.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ApplicationMessages.java
@@ -1,9 +1,10 @@
 package com.cabaggregator.authservice.core.constant;
 
-import lombok.experimental.UtilityClass;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@UtilityClass
-public class ApplicationMessages {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ApplicationMessages {
     public static final String INVALID_REFRESH_TOKEN = "error.invalid.refresh.token";
     public static final String INVALID_ACCESS_TOKEN = "error.invalid.access.token";
     public static final String REFRESH_TOKEN_EXPIRED = "error.refresh.token.expired";

--- a/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ErrorCauses.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ErrorCauses.java
@@ -1,9 +1,10 @@
 package com.cabaggregator.authservice.core.constant;
 
-import lombok.experimental.UtilityClass;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@UtilityClass
-public class ErrorCauses {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ErrorCauses {
     public static final String BAD_REQUEST = "error.cause.bad.request";
     public static final String VALIDATION = "error.cause.validation";
     public static final String UNAUTHORIZED = "error.cause.unauthorized";

--- a/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ValidationErrors.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ValidationErrors.java
@@ -1,9 +1,10 @@
 package com.cabaggregator.authservice.core.constant;
 
-import lombok.experimental.UtilityClass;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@UtilityClass
-public class ValidationErrors {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ValidationErrors {
     public static final String INVALID_PHONE_FORMAT = "{validation.invalid.phone.format}";
     public static final String INVALID_LOGIN_IDENTIFIER = "{validation.invalid.login.identifier}";
     public static final String INVALID_STRING_LENGTH = "{validation.invalid.string.length}";
@@ -12,5 +13,4 @@ public class ValidationErrors {
     public static final String INVALID_NUMBER_VALUE = "{validation.invalid.number.value}";
     public static final String INVALID_NUMBER_MIN_VALUE = "{validation.invalid.number.min.value}";
     public static final String INVALID_NUMBER_MAX_VALUE = "{validation.invalid.number.max.value}";
-    public static final String INVALID_UUID_FORMAT = "{validation.invalid.uuid.format}";
 }

--- a/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ValidationRegex.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/core/constant/ValidationRegex.java
@@ -3,7 +3,7 @@ package com.cabaggregator.authservice.core.constant;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-public class ValidationRegex {
+public final class ValidationRegex {
     public static final String PHONE_BELARUS_FORMAT = "^375(15|29|33|44)\\d{7}$";
     public static final String EMAIL = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
 }

--- a/auth-service/src/main/java/com/cabaggregator/authservice/exception/RestExceptionHandler.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/exception/RestExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.ArrayList;
@@ -55,7 +56,10 @@ public class RestExceptionHandler {
                         messageBuilder.buildLocalizedMessage(e.getErrorCauseKey(), null)));
     }
 
-    @ExceptionHandler({HttpMessageNotReadableException.class, MissingServletRequestParameterException.class})
+    @ExceptionHandler({
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class})
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(Exception e) {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)

--- a/auth-service/src/main/java/com/cabaggregator/authservice/keycloak/util/KeycloakErrorMessages.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/keycloak/util/KeycloakErrorMessages.java
@@ -1,9 +1,10 @@
 package com.cabaggregator.authservice.keycloak.util;
 
-import lombok.experimental.UtilityClass;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@UtilityClass
-public class KeycloakErrorMessages {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class KeycloakErrorMessages {
     public static final String USER_WITH_SAME_EMAIL_EXISTS = "User exists with same email";
     public static final String USER_WITH_SAME_USERNAME_EXISTS = "User exists with same username";
     public static final String INVALID_REFRESH_TOKEN = "Invalid refresh token";

--- a/auth-service/src/main/java/com/cabaggregator/authservice/keycloak/util/KeycloakResponseValidator.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/keycloak/util/KeycloakResponseValidator.java
@@ -6,12 +6,13 @@ import com.cabaggregator.authservice.exception.DataUniquenessConflictException;
 import com.cabaggregator.authservice.exception.UnauthorizedException;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.core.Response;
-import lombok.experimental.UtilityClass;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.keycloak.representations.idm.ErrorRepresentation;
 import org.springframework.http.HttpStatus;
 
-@UtilityClass
-public class KeycloakResponseValidator {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class KeycloakResponseValidator {
 
     public static void validate(Response response) {
         HttpStatus statusCode = HttpStatus.valueOf(response.getStatus());
@@ -30,8 +31,7 @@ public class KeycloakResponseValidator {
 
     private static String handleConflict(String errorMessage) {
         return switch (errorMessage) {
-            case KeycloakErrorMessages.USER_WITH_SAME_EMAIL_EXISTS ->
-                    ApplicationMessages.REGISTER_USER_WITH_USED_EMAIL;
+            case KeycloakErrorMessages.USER_WITH_SAME_EMAIL_EXISTS -> ApplicationMessages.REGISTER_USER_WITH_USED_EMAIL;
             case KeycloakErrorMessages.USER_WITH_SAME_USERNAME_EXISTS ->
                     ApplicationMessages.REGISTER_USER_WITH_USED_PHONE;
             default -> throw new InternalServerErrorException(
@@ -41,8 +41,7 @@ public class KeycloakResponseValidator {
 
     private static String handleUnauthorized(String errorMessage) {
         return switch (errorMessage) {
-            case KeycloakErrorMessages.INVALID_REFRESH_TOKEN ->
-                    ApplicationMessages.INVALID_REFRESH_TOKEN;
+            case KeycloakErrorMessages.INVALID_REFRESH_TOKEN -> ApplicationMessages.INVALID_REFRESH_TOKEN;
             default -> throw new InternalServerErrorException(
                     buildExceptionMessage(errorMessage, HttpStatus.UNAUTHORIZED));
         };
@@ -50,10 +49,8 @@ public class KeycloakResponseValidator {
 
     private static String handleBadRequest(String errorMessage) {
         return switch (errorMessage) {
-            case KeycloakErrorMessages.INVALID_REFRESH_TOKEN ->
-                    ApplicationMessages.INVALID_REFRESH_TOKEN;
-            case KeycloakErrorMessages.REFRESH_TOKEN_EXPIRED ->
-                    ApplicationMessages.REFRESH_TOKEN_EXPIRED;
+            case KeycloakErrorMessages.INVALID_REFRESH_TOKEN -> ApplicationMessages.INVALID_REFRESH_TOKEN;
+            case KeycloakErrorMessages.REFRESH_TOKEN_EXPIRED -> ApplicationMessages.REFRESH_TOKEN_EXPIRED;
             default -> throw new InternalServerErrorException(
                     buildExceptionMessage(errorMessage, HttpStatus.BAD_REQUEST));
         };

--- a/auth-service/src/main/java/com/cabaggregator/authservice/util/FeignExceptionConvertor.java
+++ b/auth-service/src/main/java/com/cabaggregator/authservice/util/FeignExceptionConvertor.java
@@ -1,0 +1,44 @@
+package com.cabaggregator.authservice.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.core.Response;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.keycloak.representations.idm.ErrorRepresentation;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FeignExceptionConvertor {
+
+    public static Response convertToKeyCloakResponse(final FeignException exception) {
+        ErrorRepresentation keycloakError = new ErrorRepresentation();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            ByteBuffer responseBody = exception
+                    .responseBody()
+                    .orElseThrow(() -> new InternalServerErrorException(exception.getMessage()));
+
+            String body = new String(
+                    responseBody.array(),
+                    StandardCharsets.UTF_8);
+
+            JsonNode jsonNode = objectMapper.readTree(body);
+            String errorDescription = jsonNode.get("error_description").asText();
+
+            keycloakError.setErrorMessage(errorDescription);
+        } catch (Exception e) {
+            throw new InternalServerErrorException();
+        }
+
+        return Response
+                .status(exception.status())
+                .entity(keycloakError)
+                .build();
+    }
+}

--- a/auth-service/src/main/resources/validation_errors.properties
+++ b/auth-service/src/main/resources/validation_errors.properties
@@ -6,4 +6,3 @@ validation.invalid.string.max.length=length must be less than {max} symbols
 validation.invalid.number.value=value must be between {min} and {max}
 validation.invalid.number.min.value=value must  be at least {min}
 validation.invalid.number.max.value=value must be less than {max}
-validation.invalid.uuid.format=illegal format, correct example: xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx

--- a/auth-service/src/main/resources/validation_errors_ru.properties
+++ b/auth-service/src/main/resources/validation_errors_ru.properties
@@ -6,4 +6,3 @@ validation.invalid.string.max.length=длина должна быть меньш
 validation.invalid.number.value=значение должно быть между {min} и {max}
 validation.invalid.number.min.value=значение должно быть не менее {min}
 validation.invalid.number.max.value=значение должно быть меньше {max}
-validation.invalid.uuid.format=неправильный формат, правильный пример: xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx


### PR DESCRIPTION
**This pull request adds exception handler for Keycloak FeignClient in auth service.**

_Functionality_

FeignExceptionConvertor converts FeignException to jakarta Response that returned by Keycloak server. Then Reponse is handled in KeycloakResponseValidator. FeignExceptionConvertor is like adapter for keycloak-admin-client and FeignClient.