### PR TITLE
feat(payout-service): add DTOs & API definition

### DIFF
--- a/payout-service/pom.xml
+++ b/payout-service/pom.xml
@@ -17,12 +17,17 @@
 
     <properties>
         <java.version>21</java.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -39,6 +44,16 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/controller/api/PayoutAccountController.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/controller/api/PayoutAccountController.java
@@ -1,0 +1,123 @@
+package com.cabaggregator.payoutservice.controller.api;
+
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationAddingDto;
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationDto;
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountAddingDto;
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountDto;
+import com.cabaggregator.payoutservice.core.dto.page.PageDto;
+import com.cabaggregator.payoutservice.core.enums.OperationType;
+import com.cabaggregator.payoutservice.core.enums.sort.BalanceOperationSortField;
+import com.cabaggregator.payoutservice.core.enums.sort.PayoutAccountSortField;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/payout-accounts")
+public class PayoutAccountController {
+    @GetMapping
+    public ResponseEntity<PageDto<PayoutAccountDto>> getPageOfPayoutAccounts(
+            @RequestParam(defaultValue = "0") Integer offset,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @RequestParam(defaultValue = "createdAt") PayoutAccountSortField sortBy,
+            @RequestParam(defaultValue = "ASC") Sort.Direction sortOrder) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PayoutAccountDto> getPayoutAccount(@PathVariable UUID id) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @GetMapping("/{id}/balance")
+    public ResponseEntity<Long> getPayoutAccountBalance(@PathVariable UUID id) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @GetMapping("/{id}/balance-operations")
+    public ResponseEntity<PageDto<BalanceOperationDto>> getPageOfBalanceOperations(
+            @PathVariable UUID id,
+            @RequestParam(defaultValue = "0") Integer offset,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @RequestParam(defaultValue = "createdAt") BalanceOperationSortField sortBy,
+            @RequestParam(defaultValue = "ASC") Sort.Direction sortOrder,
+            @RequestParam(required = false) OperationType operationType,
+            @RequestParam(required = false) LocalDateTime startTime,
+            @RequestParam(required = false) LocalDateTime endTime) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping
+    public ResponseEntity<PayoutAccountDto> createPayoutAccount(
+            @RequestBody PayoutAccountAddingDto addingDto) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/{id}/balance-operations/deposit")
+    public ResponseEntity<BalanceOperationDto> deposit(
+            @PathVariable UUID id,
+            @RequestBody BalanceOperationAddingDto operationAddingDto) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/{id}/balance-operations/withdraw")
+    public ResponseEntity<BalanceOperationDto> withdraw(
+            @PathVariable UUID id,
+            @RequestBody BalanceOperationAddingDto operationAddingDto) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/{id}/balance-operations/bonus")
+    public ResponseEntity<BalanceOperationDto> sendBonus(
+            @PathVariable UUID id,
+            @RequestBody BalanceOperationAddingDto operationAddingDto) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/{id}/balance-operations/fine")
+    public ResponseEntity<BalanceOperationDto> imposeFine(
+            @PathVariable UUID id,
+            @RequestBody BalanceOperationAddingDto operationAddingDto) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PayoutAccountDto> updatePayoutAccount(
+            @PathVariable UUID id,
+            @RequestBody String stripeAccountId) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PutMapping("/{id}/activate")
+    public ResponseEntity<Void> activatePayoutAccount(@PathVariable UUID id) {
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PutMapping("/{id}/deactivate")
+    public ResponseEntity<Void> deactivatePayoutAccount(@PathVariable UUID id) {
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/BalanceOperationAddingDto.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/BalanceOperationAddingDto.java
@@ -1,0 +1,7 @@
+package com.cabaggregator.payoutservice.core.dto;
+
+public record BalanceOperationAddingDto(
+        Long amount,
+        String transcript
+) {
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/BalanceOperationDto.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/BalanceOperationDto.java
@@ -1,0 +1,16 @@
+package com.cabaggregator.payoutservice.core.dto;
+
+import com.cabaggregator.payoutservice.core.enums.OperationType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record BalanceOperationDto(
+        Long id,
+        UUID payoutAccountId,
+        Long amount,
+        OperationType type,
+        String transcript,
+        LocalDateTime createdAt
+) {
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/PayoutAccountAddingDto.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/PayoutAccountAddingDto.java
@@ -1,0 +1,9 @@
+package com.cabaggregator.payoutservice.core.dto;
+
+import java.util.UUID;
+
+public record PayoutAccountAddingDto(
+        UUID id,
+        String stripeAccountId
+) {
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/PayoutAccountDto.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/PayoutAccountDto.java
@@ -1,0 +1,12 @@
+package com.cabaggregator.payoutservice.core.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PayoutAccountDto(
+        UUID id,
+        String stripeAccountId,
+        LocalDateTime createdAt,
+        Boolean active
+) {
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/page/PageDto.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/dto/page/PageDto.java
@@ -1,0 +1,11 @@
+package com.cabaggregator.payoutservice.core.dto.page;
+
+import java.util.List;
+
+public record PageDto<T>(
+        Integer page,
+        Integer pageSize,
+        Integer totalPages,
+        List<T> content
+) {
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/enums/OperationType.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/enums/OperationType.java
@@ -1,4 +1,4 @@
-package com.cabaggregator.payoutservice.entity.enums;
+package com.cabaggregator.payoutservice.core.enums;
 
 public enum OperationType {
     DEPOSIT,

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/enums/sort/BalanceOperationSortField.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/enums/sort/BalanceOperationSortField.java
@@ -1,0 +1,15 @@
+package com.cabaggregator.payoutservice.core.enums.sort;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BalanceOperationSortField {
+    ID("id"),
+    CREATED_AT("createdAt"),
+    TYPE("type"),
+    AMOUNT("amount");
+
+    private final String value;
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/enums/sort/PayoutAccountSortField.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/enums/sort/PayoutAccountSortField.java
@@ -1,0 +1,13 @@
+package com.cabaggregator.payoutservice.core.enums.sort;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PayoutAccountSortField {
+    ID("id"),
+    CREATED_AT("createdAt");
+
+    private final String value;
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/mapper/BalanceOperationMapper.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/mapper/BalanceOperationMapper.java
@@ -1,0 +1,27 @@
+package com.cabaggregator.payoutservice.core.mapper;
+
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationAddingDto;
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationDto;
+import com.cabaggregator.payoutservice.entity.BalanceOperation;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.List;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface BalanceOperationMapper {
+    @Mapping(source = "payoutAccount.id", target = "payoutAccountId")
+    BalanceOperationDto entityToDto(BalanceOperation entity);
+
+    BalanceOperation dtoToEntity(BalanceOperationAddingDto dto);
+
+    List<BalanceOperationDto> entityListToDtoList(List<BalanceOperation> enitityList);
+
+    default Page<BalanceOperationDto> entityPageToDtoPage(Page<BalanceOperation> entityPage) {
+        List<BalanceOperationDto> dtoList = entityListToDtoList(entityPage.getContent());
+        return new PageImpl<>(dtoList, entityPage.getPageable(), entityPage.getTotalElements());
+    }
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/mapper/PageMapper.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/mapper/PageMapper.java
@@ -1,0 +1,17 @@
+package com.cabaggregator.payoutservice.core.mapper;
+
+import com.cabaggregator.payoutservice.core.dto.page.PageDto;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PageMapper {
+    public <T> PageDto<T> pageToPageDto(Page<T> page) {
+        return new PageDto<>(
+                page.getPageable().getPageNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getContent()
+        );
+    }
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/core/mapper/PayoutAccountMapper.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/core/mapper/PayoutAccountMapper.java
@@ -1,0 +1,25 @@
+package com.cabaggregator.payoutservice.core.mapper;
+
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountAddingDto;
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountDto;
+import com.cabaggregator.payoutservice.entity.PayoutAccount;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.List;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface PayoutAccountMapper {
+    PayoutAccount dtoToEntity(PayoutAccountAddingDto dto);
+
+    PayoutAccountDto entityToDto(PayoutAccount entity);
+
+    List<PayoutAccountDto> entityListToDtoList(List<PayoutAccount> enitityList);
+
+    default Page<PayoutAccountDto> entityPageToDtoPage(Page<PayoutAccount> entityPage) {
+        List<PayoutAccountDto> dtoList = entityListToDtoList(entityPage.getContent());
+        return new PageImpl<>(dtoList, entityPage.getPageable(), entityPage.getTotalElements());
+    }
+}

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/BalanceOperation.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/BalanceOperation.java
@@ -1,6 +1,6 @@
 package com.cabaggregator.payoutservice.entity;
 
-import com.cabaggregator.payoutservice.entity.enums.OperationType;
+import com.cabaggregator.payoutservice.core.enums.OperationType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/repository/BalanceOperationRepository.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/repository/BalanceOperationRepository.java
@@ -1,8 +1,8 @@
 package com.cabaggregator.payoutservice.repository;
 
+import com.cabaggregator.payoutservice.core.enums.OperationType;
 import com.cabaggregator.payoutservice.entity.BalanceOperation;
 import com.cabaggregator.payoutservice.entity.PayoutAccount;
-import com.cabaggregator.payoutservice.entity.enums.OperationType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/integration/repository/BalanceOperationRepositoryTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/integration/repository/BalanceOperationRepositoryTest.java
@@ -1,9 +1,9 @@
 package com.cabaggregator.payoutservice.integration.repository;
 
 import com.cabaggregator.payoutservice.config.AbstractIntegrationTest;
+import com.cabaggregator.payoutservice.core.enums.OperationType;
 import com.cabaggregator.payoutservice.entity.BalanceOperation;
 import com.cabaggregator.payoutservice.entity.PayoutAccount;
-import com.cabaggregator.payoutservice.entity.enums.OperationType;
 import com.cabaggregator.payoutservice.repository.BalanceOperationRepository;
 import com.cabaggregator.payoutservice.util.BalanceOperationTestUtil;
 import com.cabaggregator.payoutservice.util.PayoutAccountTestUtil;

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/BalanceOperationMapperTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/BalanceOperationMapperTest.java
@@ -1,0 +1,121 @@
+package com.cabaggregator.payoutservice.unit.core.mapper;
+
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationAddingDto;
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationDto;
+import com.cabaggregator.payoutservice.core.mapper.BalanceOperationMapper;
+import com.cabaggregator.payoutservice.entity.BalanceOperation;
+import com.cabaggregator.payoutservice.entity.PayoutAccount;
+import com.cabaggregator.payoutservice.util.BalanceOperationTestUtil;
+import com.cabaggregator.payoutservice.util.PaginationTestUtil;
+import com.cabaggregator.payoutservice.util.PayoutAccountTestUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class BalanceOperationMapperTest {
+    private final BalanceOperationMapper mapper = Mappers.getMapper(BalanceOperationMapper.class);
+
+    private BalanceOperation buildBalanceOperation() {
+        PayoutAccount account = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+
+        return BalanceOperationTestUtil
+                .getBalanceOperationBuilder()
+                .payoutAccount(account)
+                .build();
+    }
+
+    @Test
+    void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
+        BalanceOperation balanceOperation = buildBalanceOperation();
+        BalanceOperationDto balanceOperationDto = BalanceOperationTestUtil.buildBalanceOperationDto();
+
+        BalanceOperationDto actual = mapper.entityToDto(balanceOperation);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(balanceOperationDto);
+    }
+
+    @Test
+    void entityToDto_ShouldReturnNull_WhenEntityIsNull() {
+        assertThat(mapper.entityToDto(null)).isNull();
+    }
+
+    @Test
+    void dtoToEntity_ShouldConvertEntityToDto_WhenDtoIsNotNull() {
+        BalanceOperation balanceOperation = buildBalanceOperation();
+        BalanceOperationAddingDto balanceOperationAddingDto = BalanceOperationTestUtil.buildBalanceOperationAddingDto();
+
+        BalanceOperation actual = mapper.dtoToEntity(balanceOperationAddingDto);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isNull();
+        assertThat(actual.getPayoutAccount()).isNull();
+        assertThat(actual.getAmount()).isEqualTo(balanceOperation.getAmount());
+        assertThat(actual.getType()).isNull();
+        assertThat(actual.getTranscript()).isEqualTo(balanceOperation.getTranscript());
+        assertThat(actual.getCreatedAt()).isNull();
+    }
+
+    @Test
+    void dtoToEntity_ShouldReturnNull_WhenDtoIsNull() {
+        assertThat(mapper.dtoToEntity(null)).isNull();
+    }
+
+    @Test
+    void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
+        BalanceOperation balanceOperation = buildBalanceOperation();
+        List<BalanceOperation> entityList = Arrays.asList(balanceOperation, balanceOperation);
+        BalanceOperationDto balanceOperationDto = BalanceOperationTestUtil.buildBalanceOperationDto();
+        List<BalanceOperationDto> dtoList = Arrays.asList(balanceOperationDto, balanceOperationDto);
+
+        List<BalanceOperationDto> actual = mapper.entityListToDtoList(entityList);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(dtoList);
+    }
+
+    @Test
+    void entityListToDtoList_ShouldReturnEmptyList_WhenEntityListIsEmpty() {
+        List<BalanceOperation> entityList = Collections.emptyList();
+
+        List<BalanceOperationDto> actual = mapper.entityListToDtoList(entityList);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEmpty();
+    }
+
+    @Test
+    void entityListToDtoList_ShouldReturnNull_WhenEntityListIsNull() {
+        assertThat(mapper.entityListToDtoList(null)).isNull();
+    }
+
+    @Test
+    void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
+        BalanceOperation balanceOperation = buildBalanceOperation();
+        List<BalanceOperation> entityList = Arrays.asList(balanceOperation, balanceOperation);
+        Page<BalanceOperation> entityPage = PaginationTestUtil.buildPageFromList(entityList);
+        BalanceOperationDto balanceOperationDto = BalanceOperationTestUtil.buildBalanceOperationDto();
+        List<BalanceOperationDto> dtoList = Arrays.asList(balanceOperationDto, balanceOperationDto);
+        Page<BalanceOperationDto> expectedDtoPage = PaginationTestUtil.buildPageFromList(dtoList);
+
+        Page<BalanceOperationDto> actual = mapper.entityPageToDtoPage(entityPage);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(expectedDtoPage);
+    }
+}

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/PageMapperTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/PageMapperTest.java
@@ -1,0 +1,51 @@
+package com.cabaggregator.payoutservice.unit.core.mapper;
+
+import com.cabaggregator.payoutservice.core.dto.page.PageDto;
+import com.cabaggregator.payoutservice.core.mapper.PageMapper;
+import com.cabaggregator.payoutservice.util.PaginationTestUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+class PageMapperTest {
+    private final PageMapper mapper = new PageMapper();
+
+    @Test
+    void pageToPagedDto_ShouldReturnPagedDto_WhenPageIsNotEmpty() {
+        Integer pageNumber = 0, pageSize = 10;
+        List<Object> expectedContent = Arrays.asList("item1", "item2");
+        Page<Object> page = PaginationTestUtil.buildPageFromList(expectedContent, pageNumber, pageSize);
+
+        PageDto<Object> actual = mapper.pageToPageDto(page);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.page()).isEqualTo(pageNumber);
+        assertThat(actual.pageSize()).isEqualTo(pageSize);
+        assertThat(actual.totalPages()).isEqualTo(page.getTotalPages());
+        assertThat(actual.content()).isEqualTo(expectedContent);
+    }
+
+    @Test
+    void pageToPagedDto_ShouldReturnPagedDtoWithNoContent_WhenPageIsEmpty() {
+        Integer pageNumber = 0, pageSize = 10;
+        List<Object> expectedContent = Collections.emptyList();
+        Page<Object> page = PaginationTestUtil.buildPageFromList(expectedContent, pageNumber, pageSize);
+
+        PageDto<Object> actual = mapper.pageToPageDto(page);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.page()).isEqualTo(pageNumber);
+        assertThat(actual.pageSize()).isEqualTo(pageSize);
+        assertThat(actual.totalPages()).isEqualTo(page.getTotalPages());
+        assertThat(actual.content())
+                .isNotNull()
+                .isEqualTo(expectedContent);
+    }
+}

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/PayoutAccountMapperTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/PayoutAccountMapperTest.java
@@ -1,0 +1,107 @@
+package com.cabaggregator.payoutservice.unit.core.mapper;
+
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountAddingDto;
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountDto;
+import com.cabaggregator.payoutservice.core.mapper.PayoutAccountMapper;
+import com.cabaggregator.payoutservice.entity.PayoutAccount;
+import com.cabaggregator.payoutservice.util.PaginationTestUtil;
+import com.cabaggregator.payoutservice.util.PayoutAccountTestUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class PayoutAccountMapperTest {
+    private final PayoutAccountMapper mapper = Mappers.getMapper(PayoutAccountMapper.class);
+
+    @Test
+    void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccountDto payoutAccountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
+
+        PayoutAccountDto actual = mapper.entityToDto(payoutAccount);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(payoutAccountDto);
+    }
+
+    @Test
+    void entityToDto_ShouldReturnNull_WhenEntityIsNull() {
+        assertThat(mapper.entityToDto(null)).isNull();
+    }
+
+    @Test
+    void dtoToEntity_ShouldConvertDtoToEntity_WhenDtoIsNotNull() {
+        PayoutAccountAddingDto payoutAccountAddingDto = PayoutAccountTestUtil.buildPayoutAccountAddingDto();
+
+        PayoutAccount actual = mapper.dtoToEntity(payoutAccountAddingDto);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isEqualTo(payoutAccountAddingDto.id());
+        assertThat(actual.getStripeAccountId()).isEqualTo(payoutAccountAddingDto.stripeAccountId());
+        assertThat(actual.getActive()).isNull();
+        assertThat(actual.getCreatedAt()).isNull();
+    }
+
+    @Test
+    void dtoToEntity_ShouldReturnNull_WhenDtoIsNull() {
+        assertThat(mapper.dtoToEntity(null)).isNull();
+    }
+
+    @Test
+    void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        List<PayoutAccount> entityList = Arrays.asList(payoutAccount, payoutAccount);
+        PayoutAccountDto payoutAccountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
+        List<PayoutAccountDto> dtoList = Arrays.asList(payoutAccountDto, payoutAccountDto);
+
+        List<PayoutAccountDto> actual = mapper.entityListToDtoList(entityList);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(dtoList);
+    }
+
+    @Test
+    void entityListToDtoList_ShouldReturnEmptyList_WhenEntityListIsEmpty() {
+        List<PayoutAccount> entityList = Collections.emptyList();
+
+        List<PayoutAccountDto> actual = mapper.entityListToDtoList(entityList);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEmpty();
+    }
+
+    @Test
+    void entityListToDtoList_ShouldReturnNull_WhenEntityListIsNull() {
+        assertThat(mapper.entityListToDtoList(null)).isNull();
+    }
+
+    @Test
+    void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        List<PayoutAccount> entityList = Arrays.asList(payoutAccount, payoutAccount);
+        Page<PayoutAccount> entityPage = PaginationTestUtil.buildPageFromList(entityList);
+        PayoutAccountDto payoutAccountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
+        List<PayoutAccountDto> dtoList = Arrays.asList(payoutAccountDto, payoutAccountDto);
+        Page<PayoutAccountDto> expectedDtoPage = PaginationTestUtil.buildPageFromList(dtoList);
+
+        Page<PayoutAccountDto> actual = mapper.entityPageToDtoPage(entityPage);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(expectedDtoPage);
+    }
+}

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/util/BalanceOperationTestUtil.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/util/BalanceOperationTestUtil.java
@@ -1,7 +1,9 @@
 package com.cabaggregator.payoutservice.util;
 
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationAddingDto;
+import com.cabaggregator.payoutservice.core.dto.BalanceOperationDto;
+import com.cabaggregator.payoutservice.core.enums.OperationType;
 import com.cabaggregator.payoutservice.entity.BalanceOperation;
-import com.cabaggregator.payoutservice.entity.enums.OperationType;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -29,5 +31,21 @@ public final class BalanceOperationTestUtil {
                 .type(TYPE)
                 .transcript(TRANSCRIPT)
                 .createdAt(CREATED_AT);
+    }
+
+    public static BalanceOperationDto buildBalanceOperationDto() {
+        return new BalanceOperationDto(
+                ID,
+                PayoutAccountTestUtil.ID,
+                AMOUNT,
+                TYPE,
+                TRANSCRIPT,
+                CREATED_AT);
+    }
+
+    public static BalanceOperationAddingDto buildBalanceOperationAddingDto() {
+        return new BalanceOperationAddingDto(
+                AMOUNT,
+                TRANSCRIPT);
     }
 }

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/util/PaginationTestUtil.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/util/PaginationTestUtil.java
@@ -1,0 +1,39 @@
+package com.cabaggregator.payoutservice.util;
+
+import com.cabaggregator.payoutservice.core.dto.page.PageDto;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.Collections;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PaginationTestUtil {
+    public static PageRequest buildPageRequest(int offset, int limit, String sortField, Sort.Direction sortOrder) {
+        return PageRequest.of(offset, limit, Sort.by(sortOrder, sortField));
+    }
+
+    public static <T> Page<T> buildPageFromSingleElement(T element) {
+        return new PageImpl<>(Collections.singletonList(element));
+    }
+
+    public static <T> Page<T> buildPageFromList(List<T> elements) {
+        return new PageImpl<>(elements);
+    }
+
+    public static <T> Page<T> buildPageFromList(List<T> elements, Integer pageNumber, Integer pageSize) {
+        return new PageImpl<>(elements, PageRequest.of(pageNumber, pageSize), elements.size());
+    }
+
+    public static <T> PageDto<T> buildPageDto(Page<T> page) {
+        return new PageDto<>(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getContent());
+    }
+}

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/util/PayoutAccountTestUtil.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/util/PayoutAccountTestUtil.java
@@ -1,5 +1,7 @@
 package com.cabaggregator.payoutservice.util;
 
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountAddingDto;
+import com.cabaggregator.payoutservice.core.dto.PayoutAccountDto;
 import com.cabaggregator.payoutservice.entity.PayoutAccount;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -32,5 +34,19 @@ public final class PayoutAccountTestUtil {
                 .id(NOT_EXISTING_ID)
                 .stripeAccountId(NOT_EXISTING_STRIPE_ACCOUNT_ID)
                 .build();
+    }
+
+    public static PayoutAccountDto buildPayoutAccountDto() {
+        return new PayoutAccountDto(
+                ID,
+                STRIPE_ACCOUNT_ID,
+                CREATED_AT,
+                ACTIVE);
+    }
+
+    public static PayoutAccountAddingDto buildPayoutAccountAddingDto() {
+        return new PayoutAccountAddingDto(
+                ID,
+                STRIPE_ACCOUNT_ID);
     }
 }


### PR DESCRIPTION
**This pull request adds DTOs; define API in payout service.**

_Released application features in chronological order:_

1. DTOs:
- Added necessary DTOs for payout accounts, operations above them.
2. API:
- Added definition of main API functionality
3. Testing:
- Refactored test utils for models
- Added unit tests of mappers

**API architecture**

Managing Payout Accounts:
GET /api/v1/payout-accounts – Retrieve a list of payout accounts.
GET /api/v1/payout-accounts/{id} – Retrieve details of a specific payout account.
GET /api/v1/payout-accounts/{id}/balance – Retrieve the balance of a payout account.
POST /api/v1/payout-accounts – Create a new payout account.
PUT /api/v1/payout-accounts/{id} – Update payout account details.
PUT /api/v1/payout-accounts/{id}/activate – Activate a payout account.
PUT /api/v1/payout-accounts/{id}/deactivate – Deactivate a payout account

Managing Balance Operations:
GET /api/v1/payout-accounts/{id}/balance-operations – Retrieve a list of balance operations.
POST /api/v1/payout-accounts/{id}/balance-operations/deposit – Add funds to the balance.
POST /api/v1/payout-accounts/{id}/balance-operations/withdraw – Withdraw funds from the balance.
POST /api/v1/payout-accounts/{id}/balance-operations/bonus – Add a bonus to the balance.
POST /api/v1/payout-accounts/{id}/balance-operations/fine – Impose a fine on the balance.
