### PR TITLE
feat(ride-service): add DTOs & API definition

### DIFF
--- a/ride-service/pom.xml
+++ b/ride-service/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <java.version>21</java.version>
         <mongock.version>5.5.0</mongock.version>
+        <mapstruct.version>1.5.5.Final</mapstruct.version>
     </properties>
 
     <dependencyManagement>
@@ -42,9 +43,23 @@
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/controller/api/RideController.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/controller/api/RideController.java
@@ -1,0 +1,76 @@
+package com.cabaggregator.rideservice.controller.api;
+
+import com.cabaggregator.rideservice.core.RideAddingDto;
+import com.cabaggregator.rideservice.core.RideDto;
+import com.cabaggregator.rideservice.core.RideUpdatingDto;
+import com.cabaggregator.rideservice.core.dto.page.PageDto;
+import com.cabaggregator.rideservice.core.enums.PaymentStatus;
+import com.cabaggregator.rideservice.core.enums.RideStatus;
+import com.cabaggregator.rideservice.core.enums.sort.RideSortField;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/rides")
+public class RideController {
+
+    @GetMapping
+    public ResponseEntity<PageDto<RideDto>> getPageOfRides(
+            @RequestParam(defaultValue = "0") Integer offset,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @RequestParam(defaultValue = "id") RideSortField sortBy,
+            @RequestParam(defaultValue = "ASC") Sort.Direction sortOrder,
+            @RequestParam(name = "status") RideStatus status) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RideDto> getRide(@PathVariable ObjectId id) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping
+    public ResponseEntity<RideDto> createRide(@RequestBody RideAddingDto addingDto) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<RideDto> updateRide(
+            @PathVariable ObjectId id,
+            @RequestBody RideUpdatingDto updatingDto) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<RideDto> changeRideStatus(
+            @PathVariable ObjectId id,
+            @RequestBody RideStatus status) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PatchMapping("/{id}/payment-status")
+    public ResponseEntity<RideDto> changeRidePaymentStatus(
+            @PathVariable ObjectId id,
+            @RequestBody PaymentStatus paymentStatus) {
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/core/RideAddingDto.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/core/RideAddingDto.java
@@ -1,0 +1,13 @@
+package com.cabaggregator.rideservice.core;
+
+import com.cabaggregator.rideservice.core.dto.Address;
+import com.cabaggregator.rideservice.core.enums.PaymentMethod;
+import com.cabaggregator.rideservice.core.enums.RideFare;
+
+public record RideAddingDto(
+        RideFare fare,
+        PaymentMethod paymentMethod,
+        Address pickUpAddress,
+        Address dropOffAddress
+) {
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/core/RideDto.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/core/RideDto.java
@@ -1,0 +1,31 @@
+package com.cabaggregator.rideservice.core;
+
+import com.cabaggregator.rideservice.core.dto.Address;
+import com.cabaggregator.rideservice.core.enums.PaymentMethod;
+import com.cabaggregator.rideservice.core.enums.PaymentStatus;
+import com.cabaggregator.rideservice.core.enums.RideFare;
+import com.cabaggregator.rideservice.core.enums.RideStatus;
+import org.bson.types.ObjectId;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record RideDto(
+        ObjectId id,
+        UUID passengerId,
+        UUID driverId,
+        String promoCode,
+        RideFare fare,
+        RideStatus status,
+        PaymentMethod paymentMethod,
+        PaymentStatus paymentStatus,
+        Address pickUpAddress,
+        Address dropOffAddress,
+        Long price,
+        LocalDateTime orderTime,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        Duration estimatedDuration
+) {
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/core/RideUpdatingDto.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/core/RideUpdatingDto.java
@@ -1,0 +1,11 @@
+package com.cabaggregator.rideservice.core;
+
+import com.cabaggregator.rideservice.core.dto.Address;
+import com.cabaggregator.rideservice.core.enums.PaymentMethod;
+
+public record RideUpdatingDto(
+        PaymentMethod paymentMethod,
+        Address pickUpAddress,
+        Address dropOffAddress
+) {
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/core/dto/page/PageDto.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/core/dto/page/PageDto.java
@@ -1,0 +1,11 @@
+package com.cabaggregator.rideservice.core.dto.page;
+
+import java.util.List;
+
+public record PageDto<T>(
+        Integer page,
+        Integer pageSize,
+        Integer totalPages,
+        List<T> content
+) {
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/core/enums/PaymentStatus.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/core/enums/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.cabaggregator.rideservice.core.enums;
+
+public enum PaymentStatus {
+    PENDING,
+    DECLINED,
+    PAID_IN_CASH,
+    PAID
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/core/enums/sort/RideSortField.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/core/enums/sort/RideSortField.java
@@ -1,0 +1,17 @@
+package com.cabaggregator.rideservice.core.enums.sort;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RideSortField {
+    ID("id"),
+    ORDERED("orderTime"),
+    STARTED("startTime"),
+    ENDED("endTime"),
+    PRICE("price"),
+    DURATION("estimatedDuration");
+
+    private final String value;
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/entity/Ride.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/entity/Ride.java
@@ -2,6 +2,7 @@ package com.cabaggregator.rideservice.entity;
 
 import com.cabaggregator.rideservice.core.dto.Address;
 import com.cabaggregator.rideservice.core.enums.PaymentMethod;
+import com.cabaggregator.rideservice.core.enums.PaymentStatus;
 import com.cabaggregator.rideservice.core.enums.RideFare;
 import com.cabaggregator.rideservice.core.enums.RideStatus;
 import com.cabaggregator.rideservice.util.DurationConverter;
@@ -42,6 +43,8 @@ public class Ride {
     private RideStatus status;
 
     private PaymentMethod paymentMethod;
+
+    private PaymentStatus paymentStatus;
 
     private Address pickUpAddress;
 

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/mapper/PageMapper.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/mapper/PageMapper.java
@@ -1,0 +1,17 @@
+package com.cabaggregator.rideservice.mapper;
+
+import com.cabaggregator.rideservice.core.dto.page.PageDto;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PageMapper {
+    public <T> PageDto<T> pageToPageDto(Page<T> page) {
+        return new PageDto<>(
+                page.getPageable().getPageNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getContent()
+        );
+    }
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/mapper/RideMapper.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/mapper/RideMapper.java
@@ -1,0 +1,29 @@
+package com.cabaggregator.rideservice.mapper;
+
+import com.cabaggregator.rideservice.core.RideAddingDto;
+import com.cabaggregator.rideservice.core.RideDto;
+import com.cabaggregator.rideservice.core.RideUpdatingDto;
+import com.cabaggregator.rideservice.entity.Ride;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.MappingTarget;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.util.List;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface RideMapper {
+    RideDto entityToDto(Ride ride);
+
+    Ride dtoToEntity(RideAddingDto dto);
+
+    void updateEntityFromOrderDto(RideUpdatingDto dto, @MappingTarget Ride ride);
+
+    List<RideDto> entityListToDtoList(List<Ride> rides);
+
+    default Page<RideDto> entityPageToDtoPage(Page<Ride> entityPage) {
+        List<RideDto> dtoList = entityListToDtoList(entityPage.getContent());
+        return new PageImpl<>(dtoList, entityPage.getPageable(), entityPage.getTotalElements());
+    }
+}

--- a/ride-service/src/test/java/com/cabaggregator/rideservice/unit/core/mapper/PageMapperTest.java
+++ b/ride-service/src/test/java/com/cabaggregator/rideservice/unit/core/mapper/PageMapperTest.java
@@ -1,0 +1,52 @@
+package com.cabaggregator.rideservice.unit.core.mapper;
+
+import com.cabaggregator.rideservice.core.dto.page.PageDto;
+import com.cabaggregator.rideservice.mapper.PageMapper;
+import com.cabaggregator.rideservice.util.PaginationTestUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("unit")
+class PageMapperTest {
+    private final PageMapper mapper = new PageMapper();
+
+    @Test
+    void pageToPagedDto_ShouldReturnPagedDto_WhenPageIsNotEmpty() {
+        Integer pageNumber = 0;
+        Integer pageSize = 10;
+        List<Object> expectedContent = Arrays.asList("item1", "item2");
+        Page<Object> page = PaginationTestUtil.buildPageFromList(expectedContent, pageNumber, pageSize);
+
+        PageDto<Object> actual = mapper.pageToPageDto(page);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.page()).isEqualTo(pageNumber);
+        assertThat(actual.pageSize()).isEqualTo(pageSize);
+        assertThat(actual.totalPages()).isEqualTo(page.getTotalPages());
+        assertThat(actual.content()).isEqualTo(expectedContent);
+    }
+
+    @Test
+    void pageToPagedDto_ShouldReturnPagedDtoWithNoContent_WhenPageIsEmpty() {
+        Integer pageNumber = 0, pageSize = 10;
+        List<Object> expectedContent = Collections.emptyList();
+        Page<Object> page = PaginationTestUtil.buildPageFromList(expectedContent, pageNumber, pageSize);
+
+        PageDto<Object> actual = mapper.pageToPageDto(page);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.page()).isEqualTo(pageNumber);
+        assertThat(actual.pageSize()).isEqualTo(pageSize);
+        assertThat(actual.totalPages()).isEqualTo(page.getTotalPages());
+        assertThat(actual.content())
+                .isNotNull()
+                .isEqualTo(expectedContent);
+    }
+}

--- a/ride-service/src/test/java/com/cabaggregator/rideservice/unit/core/mapper/RideMapperTest.java
+++ b/ride-service/src/test/java/com/cabaggregator/rideservice/unit/core/mapper/RideMapperTest.java
@@ -1,0 +1,133 @@
+package com.cabaggregator.rideservice.unit.core.mapper;
+
+import com.cabaggregator.rideservice.core.RideAddingDto;
+import com.cabaggregator.rideservice.core.RideDto;
+import com.cabaggregator.rideservice.core.RideUpdatingDto;
+import com.cabaggregator.rideservice.entity.Ride;
+import com.cabaggregator.rideservice.mapper.RideMapper;
+import com.cabaggregator.rideservice.util.PaginationTestUtil;
+import com.cabaggregator.rideservice.util.RideTestUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+class RideMapperTest {
+    private final RideMapper mapper = Mappers.getMapper(RideMapper.class);
+
+    @Test
+    void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
+        Ride ride = RideTestUtil.getRideBuilder().build();
+        RideDto rideDto = RideTestUtil.buildRideDto();
+
+        RideDto actual = mapper.entityToDto(ride);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(rideDto);
+    }
+
+    @Test
+    void entityToDto_ShouldReturnNull_WhenEntityIsNull() {
+        assertThat(mapper.entityToDto(null)).isNull();
+    }
+
+    @Test
+    void dtoToEntity_ShouldConvertDtoToEntity_WhenDtoIsNotNull() {
+        Ride ride = RideTestUtil.getRideBuilder().build();
+        RideAddingDto rideAddingDto = RideTestUtil.buildRideAddingDto();
+
+        Ride actual = mapper.dtoToEntity(rideAddingDto);
+
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isNull();
+        assertThat(actual.getFare()).isEqualTo(rideAddingDto.fare());
+        assertThat(actual.getPaymentMethod()).isEqualTo(rideAddingDto.paymentMethod());
+        assertThat(actual.getPickUpAddress()).isEqualTo(ride.getPickUpAddress());
+        assertThat(actual.getDropOffAddress()).isEqualTo(ride.getDropOffAddress());
+    }
+
+    @Test
+    void dtoToEntity_ShouldReturnNull_WhenDtoIsNull() {
+        assertThat(mapper.dtoToEntity(null)).isNull();
+    }
+
+    @Test
+    void updateEntityFromOrderDto_ShouldUpdateEntity_WhenDtoIsNotNull() {
+        Ride ride = RideTestUtil.getRideBuilder().build();
+        RideUpdatingDto rideUpdatingDto = RideTestUtil.buildRideUpdatingDto();
+
+        mapper.updateEntityFromOrderDto(rideUpdatingDto, ride);
+
+        assertThat(ride).isNotNull();
+        assertThat(ride.getPaymentMethod()).isEqualTo(RideTestUtil.UPDATED_PAYMENT_METHOD);
+        assertThat(ride.getPickUpAddress()).isEqualTo(RideTestUtil.buildUpdatedPickUpAddress());
+        assertThat(ride.getDropOffAddress()).isEqualTo(RideTestUtil.buildDropOffAddress());
+    }
+
+    @Test
+    void updateEntityFromOrderDto_ShouldThrowNullPointerException_WhenDtoIsNull() {
+        RideUpdatingDto rideUpdatingDto = RideTestUtil.buildRideUpdatingDto();
+
+        assertThatThrownBy(() -> mapper.updateEntityFromOrderDto(rideUpdatingDto, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenListIsNotNull() {
+        Ride ride = RideTestUtil.getRideBuilder().build();
+        List<Ride> rides = Arrays.asList(ride, ride);
+        RideDto rideDto = RideTestUtil.buildRideDto();
+        List<RideDto> expectedList = Arrays.asList(rideDto, rideDto);
+
+        List<RideDto> actual = mapper.entityListToDtoList(rides);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(expectedList);
+    }
+
+    @Test
+    void entityListToDtoList_ShouldReturnEmptyList_WhenEntityListIsEmpty() {
+        List<Ride> rides = Collections.emptyList();
+
+        List<RideDto> actual = mapper.entityListToDtoList(rides);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEmpty();
+    }
+
+    @Test
+    void entityListToDtoList_ShouldReturnNull_WhenListIsNull() {
+        assertThat(mapper.entityListToDtoList(null)).isNull();
+    }
+
+    @Test
+    void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
+        Ride ride = RideTestUtil.getRideBuilder().build();
+        List<Ride> entityList = Arrays.asList(ride, ride);
+        Page<Ride> entityPage = PaginationTestUtil.buildPageFromList(entityList);
+        RideDto rideDto = RideTestUtil.buildRideDto();
+        List<RideDto> dtoList = Arrays.asList(rideDto, rideDto);
+        Page<RideDto> expectedDtoPage = PaginationTestUtil.buildPageFromList(dtoList);
+
+        Page<RideDto> actual = mapper.entityPageToDtoPage(entityPage);
+
+        assertThat(actual)
+                .isNotNull()
+                .isEqualTo(expectedDtoPage);
+    }
+}
+

--- a/ride-service/src/test/java/com/cabaggregator/rideservice/util/PaginationTestUtil.java
+++ b/ride-service/src/test/java/com/cabaggregator/rideservice/util/PaginationTestUtil.java
@@ -1,0 +1,39 @@
+package com.cabaggregator.rideservice.util;
+
+import com.cabaggregator.rideservice.core.dto.page.PageDto;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.Collections;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PaginationTestUtil {
+    public static PageRequest buildPageRequest(int offset, int limit, String sortField, Sort.Direction sortOrder) {
+        return PageRequest.of(offset, limit, Sort.by(sortOrder, sortField));
+    }
+
+    public static <T> Page<T> buildPageFromSingleElement(T element) {
+        return new PageImpl<>(Collections.singletonList(element));
+    }
+
+    public static <T> Page<T> buildPageFromList(List<T> elements) {
+        return new PageImpl<>(elements);
+    }
+
+    public static <T> Page<T> buildPageFromList(List<T> elements, Integer pageNumber, Integer pageSize) {
+        return new PageImpl<>(elements, PageRequest.of(pageNumber, pageSize), elements.size());
+    }
+
+    public static <T> PageDto<T> buildPageDto(Page<T> page) {
+        return new PageDto<>(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getContent());
+    }
+}

--- a/ride-service/src/test/java/com/cabaggregator/rideservice/util/RideTestUtil.java
+++ b/ride-service/src/test/java/com/cabaggregator/rideservice/util/RideTestUtil.java
@@ -1,7 +1,11 @@
 package com.cabaggregator.rideservice.util;
 
+import com.cabaggregator.rideservice.core.RideAddingDto;
+import com.cabaggregator.rideservice.core.RideDto;
+import com.cabaggregator.rideservice.core.RideUpdatingDto;
 import com.cabaggregator.rideservice.core.dto.Address;
 import com.cabaggregator.rideservice.core.enums.PaymentMethod;
+import com.cabaggregator.rideservice.core.enums.PaymentStatus;
 import com.cabaggregator.rideservice.core.enums.RideFare;
 import com.cabaggregator.rideservice.core.enums.RideStatus;
 import com.cabaggregator.rideservice.entity.Ride;
@@ -23,6 +27,7 @@ public final class RideTestUtil {
     public static final RideFare FARE = RideFare.COMFORT;
     public static final RideStatus STATUS = RideStatus.COMPLETED;
     public static final PaymentMethod PAYMENT_METHOD = PaymentMethod.CARD;
+    public static final PaymentStatus PAYMENT_STATUS = PaymentStatus.PAID;
     public static final Long DISTANCE = 2400L;
     public static final Long PRICE = 1200L;
 
@@ -41,6 +46,10 @@ public final class RideTestUtil {
     public static final UUID NOT_EXISTING_DRIVER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
     public static final RideStatus NOT_EXISTING_STATUS = RideStatus.ARRIVING;
 
+    public static final PaymentMethod UPDATED_PAYMENT_METHOD = PaymentMethod.CASH;
+    public static final String UPDATED_PICK_UP_FULL_ADDRESS = "Broadway St, Los Angeles, CA 90012";
+    public static final List<Double> UPDATED_PICK_UP_COORDINATES = List.of(-118.24605588892796, 34.05469971000838);
+
     public static Ride.RideBuilder getRideBuilder() {
         return Ride.builder()
                 .id(ID)
@@ -50,6 +59,7 @@ public final class RideTestUtil {
                 .fare(FARE)
                 .status(STATUS)
                 .paymentMethod(PAYMENT_METHOD)
+                .paymentStatus(PAYMENT_STATUS)
                 .pickUpAddress(buildPickUpAddress())
                 .dropOffAddress(buildDropOffAddress())
                 .distance(DISTANCE)
@@ -60,15 +70,55 @@ public final class RideTestUtil {
                 .estimatedDuration(ESTIMATED_DURATION);
     }
 
-    private static Address buildPickUpAddress() {
+    public static Address buildPickUpAddress() {
         return new Address(
                 PICK_UP_FULL_ADDRESS,
                 PICK_UP_COORDINATES);
     }
 
-    private static Address buildDropOffAddress() {
+    public static Address buildDropOffAddress() {
         return new Address(
                 DROP_OFF_FULL_ADDRESS,
                 DROP_OFF_COORDINATES);
+    }
+
+    public static Address buildUpdatedPickUpAddress() {
+        return new Address(
+                UPDATED_PICK_UP_FULL_ADDRESS,
+                UPDATED_PICK_UP_COORDINATES);
+    }
+
+    public static RideDto buildRideDto() {
+        return new RideDto(
+                ID,
+                PASSENGER_ID,
+                DRIVER_ID,
+                PROMO_CODE,
+                FARE,
+                STATUS,
+                PAYMENT_METHOD,
+                PAYMENT_STATUS,
+                buildPickUpAddress(),
+                buildDropOffAddress(),
+                PRICE,
+                ORDER_TIME,
+                START_TIME,
+                END_TIME,
+                ESTIMATED_DURATION);
+    }
+
+    public static RideUpdatingDto buildRideUpdatingDto() {
+        return new RideUpdatingDto(
+                UPDATED_PAYMENT_METHOD,
+                buildUpdatedPickUpAddress(),
+                buildDropOffAddress());
+    }
+
+    public static RideAddingDto buildRideAddingDto() {
+        return new RideAddingDto(
+                FARE,
+                PAYMENT_METHOD,
+                buildPickUpAddress(),
+                buildDropOffAddress());
     }
 }

--- a/ride-service/src/test/resources/mongodb/rides.json
+++ b/ride-service/src/test/resources/mongodb/rides.json
@@ -7,6 +7,7 @@
     "fare": "COMFORT",
     "status": "COMPLETED",
     "paymentMethod": "CARD",
+    "paymentStatus": "PAID",
     "distance": 2400,
     "pickUpAddress": {
       "fullAddress": "123 N Main St, Los Angeles, CA 90012",
@@ -29,6 +30,7 @@
     "promoCode": null,
     "fare": "ECONOMY",
     "status": "REQUESTED",
+    "paymentStatus": "PENDING",
     "paymentMethod": "CASH",
     "distance": 4000,
     "pickUpAddress": {


### PR DESCRIPTION
**This pull request adds DTOs; define API in ride service.**

_Released application features in chronological order:_

1. DTOs:
- Added necessary DTOs for ride.
2. API:
- Added definition of main API functionality
3. Testing:
- Added more methods int test utils for model
- Added unit tests of mappers

**API architecture**

GET /api/v1/rides – Retrieve a page of rides with specified status.
GET /api/v1/rides/{id} – Retrieve details of a specific ride.
GET /api/v1/rides/{id}/status– Retrieve the status of the ride.
GET /api/v1/rides/{id}/payment-status– Retrieve the payment status of the ride.
POST /api/v1/rides – Create a new ride.
PUT /api/v1/rides/{id} – Update ride details before it starts.
PATCH /api/v1/rides/{id}/status – Set ride status.
PATCH /api/v1/rides/{id}/payment-status – Set ride payment status.
