### PR TITLE
refactor(tests): refactor default entity building

### DIFF
--- a/passenger-service/src/main/java/com/cabaggregator/passengerservice/entity/Passenger.java
+++ b/passenger-service/src/main/java/com/cabaggregator/passengerservice/entity/Passenger.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -19,7 +18,6 @@ import java.util.UUID;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode
 @Table(name = "passengers")
 public class Passenger {
     @Id

--- a/passenger-service/src/main/java/com/cabaggregator/passengerservice/entity/Passenger.java
+++ b/passenger-service/src/main/java/com/cabaggregator/passengerservice/entity/Passenger.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode

--- a/passenger-service/src/test/java/com/cabaggregator/passengerservice/integration/repository/PassengerRepositoryTest.java
+++ b/passenger-service/src/test/java/com/cabaggregator/passengerservice/integration/repository/PassengerRepositoryTest.java
@@ -27,7 +27,7 @@ class PassengerRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void findByPhoneNumber_ShouldReturnPassenger_WhenPassengerWithPhoneNumberExists() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
 
         Optional<Passenger> actual = passengerRepository.findByPhoneNumber(passenger.getPhoneNumber());
 
@@ -46,7 +46,7 @@ class PassengerRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void findByEmail_ShouldReturnPassenger_WhenPassengerWithEmailExists() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
 
         Optional<Passenger> actual = passengerRepository.findByEmail(passenger.getEmail());
 

--- a/passenger-service/src/test/java/com/cabaggregator/passengerservice/unit/core/mapper/PassengerMapperTest.java
+++ b/passenger-service/src/test/java/com/cabaggregator/passengerservice/unit/core/mapper/PassengerMapperTest.java
@@ -24,7 +24,7 @@ class PassengerMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
         PassengerDto passengerDto = PassengerTestUtil.buildPassengerDto();
 
         PassengerDto actual = mapper.entityToDto(passenger);
@@ -41,7 +41,7 @@ class PassengerMapperTest {
 
     @Test
     void updateEntityFromDto_ShouldUpdateEntity_WhenDtoIsNotNull() {
-        Passenger actual = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger actual = PassengerTestUtil.buildDefaultPassenger();
         PassengerUpdatingDto passengerUpdatingDto = PassengerTestUtil.buildPassengerUpdatingDto();
 
         mapper.updateEntityFromDto(passengerUpdatingDto, actual);
@@ -57,10 +57,9 @@ class PassengerMapperTest {
 
     @Test
     void dtoToEntity_ShouldConvertDtoToEntity_WhenDtoIsNotNull() {
-        Passenger passenger =
-                PassengerTestUtil.getPassengerBuilder()
-                        .rating(null)
-                        .build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger().toBuilder()
+                .rating(null)
+                .build();
         PassengerAddingDto passengerAddingDto = PassengerTestUtil.buildPassengerAddingDto();
 
         Passenger actual = mapper.dtoToEntity(passengerAddingDto);
@@ -77,7 +76,7 @@ class PassengerMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenListIsNotNull() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
         List<Passenger> passengers = Arrays.asList(passenger, passenger);
         PassengerDto passengerDto = PassengerTestUtil.buildPassengerDto();
         List<PassengerDto> expectedList = Arrays.asList(passengerDto, passengerDto);
@@ -107,7 +106,7 @@ class PassengerMapperTest {
 
     @Test
     void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
         List<Passenger> entityList = Arrays.asList(passenger, passenger);
         Page<Passenger> entityPage = PaginationTestUtil.buildPageFromList(entityList);
         PassengerDto passengerDto = PassengerTestUtil.buildPassengerDto();

--- a/passenger-service/src/test/java/com/cabaggregator/passengerservice/unit/service/impl/PassengerServiceImplTest.java
+++ b/passenger-service/src/test/java/com/cabaggregator/passengerservice/unit/service/impl/PassengerServiceImplTest.java
@@ -65,7 +65,7 @@ class PassengerServiceImplTest {
         PassengerSortField sortBy = PassengerSortField.ID;
         Sort.Direction sortOrder = Sort.Direction.ASC;
 
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
         PassengerDto passengerDto = PassengerTestUtil.buildPassengerDto();
 
         PageRequest pageRequest = PaginationTestUtil.buildPageRequest(offset, limit, sortBy.getValue(), sortOrder);
@@ -98,7 +98,7 @@ class PassengerServiceImplTest {
 
     @Test
     void getPassengerById_ShouldReturnPassenger_WhenPassengerFound() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
         PassengerDto passengerDto = PassengerTestUtil.buildPassengerDto();
 
         when(passengerRepository.findById(passenger.getId()))
@@ -118,7 +118,7 @@ class PassengerServiceImplTest {
 
     @Test
     void getPassengerById_ShouldThrowResourceNotFoundException_WhenPassengerNotFound() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
 
         when(passengerRepository.findById(passenger.getId()))
                 .thenReturn(Optional.empty());
@@ -132,7 +132,7 @@ class PassengerServiceImplTest {
 
     @Test
     void updatePassenger_ShouldReturnPassenger_WhenPassengerFound() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
         PassengerDto passengerDto = PassengerTestUtil.buildPassengerDto();
         PassengerUpdatingDto passengerUpdatingDto = PassengerTestUtil.buildPassengerUpdatingDto();
 
@@ -232,7 +232,7 @@ class PassengerServiceImplTest {
     @Test
     void savePassenger_ShouldReturnPassenger_WhenPassengerIsValid() {
         PassengerAddingDto passengerAddingDto = PassengerTestUtil.buildPassengerAddingDto();
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
         PassengerDto passengerDto = PassengerTestUtil.buildPassengerDto();
 
         doNothing().when(passengerValidator).validateIdUniqueness(passengerAddingDto.id());

--- a/passenger-service/src/test/java/com/cabaggregator/passengerservice/unit/validator/PassengerValidatorTest.java
+++ b/passenger-service/src/test/java/com/cabaggregator/passengerservice/unit/validator/PassengerValidatorTest.java
@@ -64,7 +64,7 @@ class PassengerValidatorTest {
 
     @Test
     void checkExistenceOfPassengerWithId_ShouldThrowResourceNotFoundException_WhenPassengerNotFound() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
 
         Mockito.when(passengerRepository.existsById(passenger.getId()))
                 .thenReturn(false);
@@ -75,7 +75,7 @@ class PassengerValidatorTest {
 
     @Test
     void checkExistenceOfPassengerWithId_ShouldNotThrowResourceNotFoundException_WhenPassengerFound() {
-        Passenger passenger = PassengerTestUtil.getPassengerBuilder().build();
+        Passenger passenger = PassengerTestUtil.buildDefaultPassenger();
 
         Mockito.when(passengerRepository.existsById(passenger.getId()))
                 .thenReturn(true);

--- a/passenger-service/src/test/java/com/cabaggregator/passengerservice/util/PassengerTestUtil.java
+++ b/passenger-service/src/test/java/com/cabaggregator/passengerservice/util/PassengerTestUtil.java
@@ -28,14 +28,15 @@ public final class PassengerTestUtil {
     public static final String UPDATED_LAST_NAME = "NewLastName";
     public static final Double UPDATED_RATING = 2.0;
 
-    public static Passenger.PassengerBuilder getPassengerBuilder() {
+    public static Passenger buildDefaultPassenger() {
         return Passenger.builder()
                 .id(ID)
                 .phoneNumber(PHONE_NUMBER)
                 .email(EMAIL)
                 .firstName(FIRST_NAME)
                 .lastName(LAST_NAME)
-                .rating(RATING);
+                .rating(RATING)
+                .build();
     }
 
     public static PassengerDto buildPassengerDto() {

--- a/payment-service/src/main/java/com/cabaggregator/paymentservice/entity/Payment.java
+++ b/payment-service/src/main/java/com/cabaggregator/paymentservice/entity/Payment.java
@@ -25,7 +25,7 @@ import java.time.LocalDateTime;
 @With
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "payments")

--- a/payment-service/src/main/java/com/cabaggregator/paymentservice/entity/PaymentAccount.java
+++ b/payment-service/src/main/java/com/cabaggregator/paymentservice/entity/PaymentAccount.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "payment_accounts")

--- a/payment-service/src/main/java/com/cabaggregator/paymentservice/entity/PaymentContext.java
+++ b/payment-service/src/main/java/com/cabaggregator/paymentservice/entity/PaymentContext.java
@@ -21,7 +21,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "payment_contexts")

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/integration/repository/PaymentAccountRepositoryTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/integration/repository/PaymentAccountRepositoryTest.java
@@ -25,9 +25,7 @@ class PaymentAccountRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void existsByStripeCustomerId_ShouldReturnTrue_WhenCustomerExists() {
-        PaymentAccount paymentAccount =
-                PaymentAccountTestUtil.getPaymentAccountBuilder()
-                        .build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
 
         paymentAccountRepository.save(paymentAccount);
 

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/integration/repository/PaymentContextRepositoryTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/integration/repository/PaymentContextRepositoryTest.java
@@ -33,9 +33,7 @@ class PaymentContextRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void findByPayment_ShouldReturnPaymentContext_WhenPaymentExists() {
-        PaymentContext paymentContext =
-                PaymentContextTestUtil.getPaymentContextBuilder()
-                        .build();
+        PaymentContext paymentContext = PaymentContextTestUtil.buildDefaultPaymentContext();
 
         Optional<PaymentContext> actual =
                 paymentContextRepository.findByPayment(
@@ -47,10 +45,9 @@ class PaymentContextRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void findByPayment_ShouldReturnEmptyOptional_WhenPaymentDoesNotExist() {
-        Payment notExistingPayment =
-                PaymentTestUtil.getPaymentBuilder()
-                        .paymentIntentId(StripeTestUtil.NOT_EXISTING_INTENT_ID)
-                        .build();
+        Payment notExistingPayment = PaymentTestUtil.buildDefaultPayment().toBuilder()
+                .paymentIntentId(StripeTestUtil.NOT_EXISTING_INTENT_ID)
+                .build();
 
         Optional<PaymentContext> actual = paymentContextRepository.findByPayment(notExistingPayment);
 
@@ -60,9 +57,7 @@ class PaymentContextRepositoryTest extends AbstractIntegrationTest {
     @Test
     void findAllByTypeAndContextId_ShouldReturnPaymentContext_WhenTypeAndContextIdAreEqualToProvided() {
         int expectedListSize = 1;
-        PaymentContext paymentContext =
-                PaymentContextTestUtil.getPaymentContextBuilder()
-                        .build();
+        PaymentContext paymentContext = PaymentContextTestUtil.buildDefaultPaymentContext();
 
         List<PaymentContext> actual =
                 paymentContextRepository.findAllByTypeAndContextId(

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/core/mapper/PaymentAccountMapperTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/core/mapper/PaymentAccountMapperTest.java
@@ -23,7 +23,7 @@ class PaymentAccountMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         PaymentAccountDto paymentAccountDto = PaymentAccountTestUtil.buildPaymentAccountDto();
 
         PaymentAccountDto actual = mapper.entityToDto(paymentAccount);
@@ -57,7 +57,7 @@ class PaymentAccountMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         PaymentAccountDto paymentAccountDto = PaymentAccountTestUtil.buildPaymentAccountDto();
         List<PaymentAccount> entityList = Arrays.asList(paymentAccount, paymentAccount);
         List<PaymentAccountDto> expectedDtoList = Arrays.asList(paymentAccountDto, paymentAccountDto);
@@ -87,7 +87,7 @@ class PaymentAccountMapperTest {
 
     @Test
     void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         List<PaymentAccount> entityList = Arrays.asList(paymentAccount, paymentAccount);
         Page<PaymentAccount> entityPage = PaginationTestUtil.buildPageFromList(entityList);
         PaymentAccountDto paymentAccountDto = PaymentAccountTestUtil.buildPaymentAccountDto();

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/core/mapper/PaymentMapperTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/core/mapper/PaymentMapperTest.java
@@ -26,8 +26,8 @@ class PaymentMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        Payment payment = PaymentTestUtil.getPaymentBuilder().build();
-        payment.setContext(PaymentContextTestUtil.getPaymentContextBuilder().build());
+        Payment payment = PaymentTestUtil.buildDefaultPayment();
+        payment.setContext(PaymentContextTestUtil.buildDefaultPaymentContext());
         PaymentDto paymentDto = PaymentTestUtil.buildPaymentDto();
 
         PaymentDto actual = mapper.entityToDto(payment);
@@ -44,8 +44,8 @@ class PaymentMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
-        Payment payment = PaymentTestUtil.getPaymentBuilder().build();
-        payment.setContext(PaymentContextTestUtil.getPaymentContextBuilder().build());
+        Payment payment = PaymentTestUtil.buildDefaultPayment();
+        payment.setContext(PaymentContextTestUtil.buildDefaultPaymentContext());
         PaymentDto paymentDto = PaymentTestUtil.buildPaymentDto();
         List<Payment> entityList = Arrays.asList(payment, payment);
         List<PaymentDto> expectedDtoList = Arrays.asList(paymentDto, paymentDto);

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentAccountServiceImplTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentAccountServiceImplTest.java
@@ -80,7 +80,7 @@ class PaymentAccountServiceImplTest {
         PaymentAccountSortField sortBy = PaymentAccountSortField.ID;
         Sort.Direction sortOrder = Sort.Direction.ASC;
 
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         PaymentAccountDto accountDto = PaymentAccountTestUtil.buildPaymentAccountDto();
 
         PageRequest pageRequest = PaginationTestUtil.buildPageRequest(offset, limit, sortBy.getValue(), sortOrder);
@@ -114,7 +114,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void getPaymentAccount_ShouldReturnPaymentAccount_WhenPaymentAccountFound() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         PaymentAccountDto accountDto = PaymentAccountTestUtil.buildPaymentAccountDto();
 
         when(paymentAccountRepository.findById(account.getId()))
@@ -134,7 +134,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void getPaymentAccount_ShouldThrowResourceNotFoundException_WhenPaymentAccountNotFound() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
 
         when(paymentAccountRepository.findById(account.getId()))
                 .thenReturn(Optional.empty());
@@ -148,7 +148,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void getAccountPaymentCards_ShouldReturnPaymentCards_WhenPaymentAccountFound() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         List<PaymentCardDto> paymentCards = Collections.singletonList(PaymentTestUtil.buildPaymentCardDto());
 
         when(paymentAccountRepository.findById(account.getId()))
@@ -183,7 +183,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void getAccountDefaultPaymentCard_ShouldReturnPaymentCard_WhenPaymentAccountFound() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         PaymentCardDto paymentCard = PaymentTestUtil.buildPaymentCardDto();
 
         when(paymentAccountRepository.findById(account.getId()))
@@ -218,7 +218,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void setAccountDefaultPaymentCard_ShouldSetDefaultPaymentCard_WhenPaymentAccountFound() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         String paymentMethodId = StripeTestUtil.METHOD_ID;
 
         when(paymentAccountRepository.findById(account.getId()))
@@ -251,7 +251,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void createPaymentAccount_ShouldReturnPaymentAccount_WhenPaymentAccountIsValid() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         PaymentAccountDto accountDto = PaymentAccountTestUtil.buildPaymentAccountDto();
         PaymentAccountAddingDto addingDto = PaymentAccountTestUtil.buildPaymentAccountAddingDto();
         Customer customer = new Customer();
@@ -298,7 +298,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void updatePaymentAccount_ShouldReturnPaymentAccount_WhenPaymentAccountFound() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         PaymentAccountDto accountDto = PaymentAccountTestUtil.buildPaymentAccountDto();
         String newStripeCustomerId = PaymentAccountTestUtil.STRIPE_CUSTOMER_ID;
 
@@ -324,7 +324,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void updatePaymentAccount_ShouldThrowDataUniquenessException_WhenStripeCustomerIdNotUnique() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         String notUniqueStripeAccountId = PaymentAccountTestUtil.STRIPE_CUSTOMER_ID;
 
         when(paymentAccountRepository.findById(account.getId()))
@@ -344,7 +344,7 @@ class PaymentAccountServiceImplTest {
 
     @Test
     void updatePaymentAccount_ShouldThrowResourceNotFoundException_WhenPaymentAccountNotFound() {
-        PaymentAccount account = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount account = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         String newStripeCustomerId = PaymentAccountTestUtil.STRIPE_CUSTOMER_ID;
 
         when(paymentAccountRepository.findById(account.getId()))

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentContextServiceImplTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentContextServiceImplTest.java
@@ -36,7 +36,7 @@ class PaymentContextServiceImplTest {
 
     @Test
     void getPaymentContextsByTypeAndContextId_ShouldReturnListOfPaymentContexts_WhenTheyFound() {
-        PaymentContext paymentContext = PaymentContextTestUtil.getPaymentContextBuilder().build();
+        PaymentContext paymentContext = PaymentContextTestUtil.buildDefaultPaymentContext();
         PaymentContextType type = paymentContext.getType();
         String contextId = paymentContext.getContextId();
         List<PaymentContext> paymentContexts = Collections.singletonList(paymentContext);
@@ -66,8 +66,8 @@ class PaymentContextServiceImplTest {
 
     @Test
     void getPaymentContext_ShouldReturnPaymentContext_WhenContextExists() {
-        Payment payment = PaymentTestUtil.getPaymentBuilder().build();
-        PaymentContext paymentContext = PaymentContextTestUtil.getPaymentContextBuilder().build();
+        Payment payment = PaymentTestUtil.buildDefaultPayment();
+        PaymentContext paymentContext = PaymentContextTestUtil.buildDefaultPaymentContext();
 
         when(paymentContextRepository.findByPayment(payment))
                 .thenReturn(Optional.of(paymentContext));
@@ -83,7 +83,7 @@ class PaymentContextServiceImplTest {
 
     @Test
     void getPaymentContext_ShouldThrowResourceNotFoundException_WhenContextDoesNotExist() {
-        Payment payment = PaymentTestUtil.getPaymentBuilder().build();
+        Payment payment = PaymentTestUtil.buildDefaultPayment();
 
         when(paymentContextRepository.findByPayment(payment))
                 .thenReturn(Optional.empty());

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentMethodServiceImplTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentMethodServiceImplTest.java
@@ -48,7 +48,7 @@ class PaymentMethodServiceImplTest {
 
     @Test
     void getPaymentCards_ShouldReturnListOfPaymentCardDto_WhenPaymentCardsExist() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         Customer stripeCustomer = new Customer();
         List<PaymentMethod> paymentCardList =
                 Collections.singletonList(StripeTestUtil.buildPaymentMethod());
@@ -75,7 +75,7 @@ class PaymentMethodServiceImplTest {
 
     @Test
     void getDefaultPaymentCard_ShouldReturnPaymentCard_WhenCustomerDefaultPaymentMethodIsCard() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         Customer stripeCustomer = new Customer();
         PaymentMethod paymentMethod = StripeTestUtil.buildPaymentMethod();
         PaymentCardDto paymentCardDto = PaymentTestUtil.buildPaymentCardDto();
@@ -100,7 +100,7 @@ class PaymentMethodServiceImplTest {
 
     @Test
     void getDefaultPaymentCard_ShouldThrowResourceNotFoundException_WhenCustomerDefaultPaymentNotFound() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         Customer stripeCustomer = new Customer();
         PaymentMethod paymentMethod = StripeTestUtil.buildPaymentMethod();
         paymentMethod.setType(PaymentMethodType.PAYPAL.getValue());
@@ -122,7 +122,7 @@ class PaymentMethodServiceImplTest {
 
     @Test
     void getDefaultPaymentCard_ShouldThrowResourceNotFoundException_WhenCustomerDefaultPaymentMethodIsNotCard() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         Customer stripeCustomer = new Customer();
         PaymentMethod paymentMethod = StripeTestUtil.buildPaymentMethod();
         paymentMethod.setType(PaymentMethodType.PAYPAL.getValue());
@@ -145,7 +145,7 @@ class PaymentMethodServiceImplTest {
 
     @Test
     void setDefaultPaymentCard_ShouldSetCustomerDefaultPaymentAsCart_WhenPaymentMethodIsCard() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         String paymentMethodId = StripeTestUtil.METHOD_ID;
         Customer stripeCustomer = new Customer();
         PaymentMethod paymentMethod = StripeTestUtil.buildPaymentMethod();
@@ -167,7 +167,7 @@ class PaymentMethodServiceImplTest {
 
     @Test
     void setDefaultPaymentCard_ShouldThrowBadRequestException_WhenCustomerDefaultPaymentMethodIsNotCard() {
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         String paymentMethodId = StripeTestUtil.METHOD_ID;
         Customer stripeCustomer = new Customer();
         PaymentMethod paymentMethod = StripeTestUtil.buildPaymentMethod();

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentServiceImplTest.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/unit/service/impl/PaymentServiceImplTest.java
@@ -76,7 +76,7 @@ class PaymentServiceImplTest {
     void getRidePayments_ShouldReturnListOfPayments_WhenTheyFound() {
         ObjectId rideId = new ObjectId(PaymentContextTestUtil.CONTEXT_ID);
         PaymentContextType contextType = PaymentContextType.RIDE;
-        PaymentContext paymentContext = PaymentContextTestUtil.getPaymentContextBuilder().build();
+        PaymentContext paymentContext = PaymentContextTestUtil.buildDefaultPaymentContext();
         List<PaymentContext> paymentContextList = Collections.singletonList(paymentContext);
         PaymentDto paymentDto = PaymentTestUtil.buildPaymentDto();
         List<PaymentDto> paymentDtoList = Collections.singletonList(paymentDto);
@@ -116,10 +116,10 @@ class PaymentServiceImplTest {
     @Test
     void createPayment_ShouldReturnPaymentResponse_WhenPaymentIntentIsCreated() {
         PaymentRequest paymentRequest = PaymentTestUtil.buildPaymentRequest();
-        PaymentAccount paymentAccount = PaymentAccountTestUtil.getPaymentAccountBuilder().build();
+        PaymentAccount paymentAccount = PaymentAccountTestUtil.buildDefaultPaymentAccount();
         Customer stripeCustomer = new Customer();
         PaymentIntent paymentIntent = StripeTestUtil.buildPaymentIntent();
-        Payment payment = PaymentTestUtil.getPaymentBuilder().build();
+        Payment payment = PaymentTestUtil.buildDefaultPayment();
         PaymentResponse paymentResponse = PaymentTestUtil.buildPaymentResponse();
         String description = String.format("Ride №%s", paymentRequest.contextId());
 
@@ -175,7 +175,7 @@ class PaymentServiceImplTest {
     void updatePaymentStatus_ShouldUpdatePaymentStatusAndDoesNotEndRide_WhenPaymentExistsAndStatusNotSucceed() {
         String paymentIntentId = StripeTestUtil.INTENT_ID;
         PaymentStatus paymentStatus = PaymentStatus.PROCESSING;
-        Payment payment = PaymentTestUtil.getPaymentBuilder().build();
+        Payment payment = PaymentTestUtil.buildDefaultPayment();
         Payment updatedPayment = payment.withStatus(paymentStatus);
 
         when(paymentRepository.findById(paymentIntentId))
@@ -214,8 +214,8 @@ class PaymentServiceImplTest {
     void updatePaymentStatus_ShouldChangeRidePaymentStatus_WhenPaymentExistsAndStatusSucceed() {
         String paymentIntentId = StripeTestUtil.INTENT_ID;
         PaymentStatus paymentStatus = PaymentStatus.SUCCEEDED;
-        Payment payment = PaymentTestUtil.getPaymentBuilder().build();
-        PaymentContext paymentContext = PaymentContextTestUtil.getPaymentContextBuilder().build();
+        Payment payment = PaymentTestUtil.buildDefaultPayment();
+        PaymentContext paymentContext = PaymentContextTestUtil.buildDefaultPaymentContext();
         ObjectId rideId = new ObjectId(paymentContext.getContextId());
 
         when(paymentRepository.findById(paymentIntentId))

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/util/PaymentAccountTestUtil.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/util/PaymentAccountTestUtil.java
@@ -23,11 +23,12 @@ public final class PaymentAccountTestUtil {
     public static final UUID NOT_EXISTING_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
     public static final String NOT_EXISTING_STRIPE_CUSTOMER_ID = "cus_000000000000000000000000";
 
-    public static PaymentAccount.PaymentAccountBuilder getPaymentAccountBuilder() {
+    public static PaymentAccount buildDefaultPaymentAccount() {
         return PaymentAccount.builder()
                 .id(ID)
                 .stripeCustomerId(STRIPE_CUSTOMER_ID)
-                .createdAt(CREATED_AT);
+                .createdAt(CREATED_AT)
+                .build();
     }
 
     public static PaymentAccountDto buildPaymentAccountDto() {

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/util/PaymentContextTestUtil.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/util/PaymentContextTestUtil.java
@@ -13,11 +13,12 @@ public final class PaymentContextTestUtil {
 
     public static final String NOT_EXISTING_CONTEXT_ID = "not_existing_id";
 
-    public static PaymentContext.PaymentContextBuilder getPaymentContextBuilder() {
+    public static PaymentContext buildDefaultPaymentContext() {
         return PaymentContext.builder()
                 .id(ID)
                 .contextId(CONTEXT_ID)
                 .payment(PaymentTestUtil.getPaymentBuilder().build())
-                .type(TYPE);
+                .type(TYPE)
+                .build();
     }
 }

--- a/payment-service/src/test/java/com/cabaggregator/paymentservice/util/PaymentTestUtil.java
+++ b/payment-service/src/test/java/com/cabaggregator/paymentservice/util/PaymentTestUtil.java
@@ -15,18 +15,19 @@ public final class PaymentTestUtil {
     public static final Long UNIT_AMOUNT = 500L;
     public static final LocalDateTime CREATED_AT = LocalDateTime.now();
 
-    public static Payment.PaymentBuilder getPaymentBuilder() {
+    public static Payment buildDefaultPayment() {
         return Payment.builder()
                 .paymentIntentId(StripeTestUtil.INTENT_ID)
-                .paymentAccount(PaymentAccountTestUtil.getPaymentAccountBuilder().build())
+                .paymentAccount(PaymentAccountTestUtil.buildDefaultPaymentAccount())
                 .status(StripeTestUtil.STATUS)
-                .createdAt(CREATED_AT);
+                .createdAt(CREATED_AT)
+                .build();
     }
 
     public static PaymentDto buildPaymentDto() {
         return new PaymentDto(
                 StripeTestUtil.INTENT_ID,
-                PaymentAccountTestUtil.getPaymentAccountBuilder().build().getId(),
+                PaymentAccountTestUtil.ID,
                 StripeTestUtil.STATUS,
                 CREATED_AT,
                 PaymentContextTestUtil.TYPE,

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/BalanceOperation.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/BalanceOperation.java
@@ -27,7 +27,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/BalanceOperation.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/BalanceOperation.java
@@ -15,7 +15,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -30,7 +29,6 @@ import java.time.LocalDateTime;
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode
 @Immutable
 @Table(name = "balance_operations", indexes = {
         @Index(name = "idx_payout_account_type_created_at", columnList = "payout_account_user_id, type")})

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/PayoutAccount.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/PayoutAccount.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,7 +21,6 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder(toBuilder = true)
-@EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "payout_accounts", indexes = {

--- a/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/PayoutAccount.java
+++ b/payout-service/src/main/java/com/cabaggregator/payoutservice/entity/PayoutAccount.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 @With
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @EqualsAndHashCode
 @NoArgsConstructor
 @AllArgsConstructor

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/integration/repository/BalanceOperationRepositoryTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/integration/repository/BalanceOperationRepositoryTest.java
@@ -38,7 +38,7 @@ class BalanceOperationRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void getBalance_ShouldReturnAccountBalance_WhenAccountExists() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
 
         Long actual = balanceOperationRepository.getBalance(payoutAccount);
 
@@ -61,9 +61,10 @@ class BalanceOperationRepositoryTest extends AbstractIntegrationTest {
         int pageNumber = 0;
         int pageSize = 10;
         int expectedContentSize = 1;
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         BalanceOperation balanceOperation =
-                BalanceOperationTestUtil.getBalanceOperationBuilder()
+                BalanceOperationTestUtil.buildDefaultBalanceOperation()
+                        .toBuilder()
                         .payoutAccount(payoutAccount)
                         .build();
 
@@ -104,9 +105,7 @@ class BalanceOperationRepositoryTest extends AbstractIntegrationTest {
     void findAllByPayoutAccountAndCreatedAtBetween_ShouldReturnEmptyPage_WhenCreatedAtIsNotBetweenProvided() {
         int pageNumber = 0;
         int pageSize = 10;
-        PayoutAccount payoutAccount =
-                PayoutAccountTestUtil.getPayoutAccountBuilder()
-                        .build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Specification<BalanceOperation> spec = Specification
                 .where(BalanceOperationSpecification.hasPayoutAccount(payoutAccount))
                 .and(BalanceOperationSpecification.hasCreatedAtBefore(
@@ -126,11 +125,10 @@ class BalanceOperationRepositoryTest extends AbstractIntegrationTest {
         int pageNumber = 0;
         int pageSize = 10;
         int expectedContentSize = 1;
-        PayoutAccount payoutAccount =
-                PayoutAccountTestUtil.getPayoutAccountBuilder()
-                        .build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         BalanceOperation balanceOperation =
-                BalanceOperationTestUtil.getBalanceOperationBuilder()
+                BalanceOperationTestUtil.buildDefaultBalanceOperation()
+                        .toBuilder()
                         .payoutAccount(payoutAccount)
                         .build();
         Specification<BalanceOperation> spec = Specification
@@ -153,9 +151,7 @@ class BalanceOperationRepositoryTest extends AbstractIntegrationTest {
     void findAllByPayoutAccountAndTypeAndCreatedAtBetween_ShouldReturnEmptyPage_WhenAccountIsNotEqualToProvided() {
         int pageNumber = 0;
         int pageSize = 10;
-        PayoutAccount payoutAccount =
-                PayoutAccountTestUtil.getPayoutAccountBuilder()
-                        .build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Specification<BalanceOperation> spec = Specification
                 .where(BalanceOperationSpecification.hasPayoutAccount(payoutAccount))
                 .and(BalanceOperationSpecification.hasOperationType(BalanceOperationTestUtil.TYPE))
@@ -173,9 +169,7 @@ class BalanceOperationRepositoryTest extends AbstractIntegrationTest {
     void findAllByPayoutAccountAndTypeAndCreatedAtBetween_ShouldReturnEmptyPage_WhenTypeIsNotEqualToProvided() {
         int pageNumber = 0;
         int pageSize = 10;
-        PayoutAccount payoutAccount =
-                PayoutAccountTestUtil.getPayoutAccountBuilder()
-                        .build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Specification<BalanceOperation> spec = Specification
                 .where(BalanceOperationSpecification.hasPayoutAccount(payoutAccount))
                 .and(BalanceOperationSpecification.hasOperationType(OperationType.WITHDRAWAL))
@@ -193,9 +187,7 @@ class BalanceOperationRepositoryTest extends AbstractIntegrationTest {
     void findAllByPayoutAccountAndTypeAndCreatedAtBetween_ShouldReturnEmptyPage_WhenCreatedAtIsNotBetweenProvided() {
         int pageNumber = 0;
         int pageSize = 10;
-        PayoutAccount payoutAccount =
-                PayoutAccountTestUtil.getPayoutAccountBuilder()
-                        .build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Specification<BalanceOperation> spec = Specification
                 .where(BalanceOperationSpecification.hasPayoutAccount(payoutAccount))
                 .and(BalanceOperationSpecification.hasOperationType(BalanceOperationTestUtil.TYPE))

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/BalanceOperationMapperTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/BalanceOperationMapperTest.java
@@ -27,10 +27,11 @@ class BalanceOperationMapperTest {
     private final BalanceOperationMapper mapper = Mappers.getMapper(BalanceOperationMapper.class);
 
     private BalanceOperation buildBalanceOperation() {
-        PayoutAccount account = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount account = PayoutAccountTestUtil.buildDefaultPayoutAccount();
 
         return BalanceOperationTestUtil
-                .getBalanceOperationBuilder()
+                .buildDefaultBalanceOperation()
+                .toBuilder()
                 .payoutAccount(account)
                 .build();
     }

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/PayoutAccountMapperTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/core/mapper/PayoutAccountMapperTest.java
@@ -26,7 +26,7 @@ class PayoutAccountMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         PayoutAccountDto payoutAccountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
 
         PayoutAccountDto actual = mapper.entityToDto(payoutAccount);
@@ -61,7 +61,7 @@ class PayoutAccountMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         List<PayoutAccount> entityList = Arrays.asList(payoutAccount, payoutAccount);
         PayoutAccountDto payoutAccountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
         List<PayoutAccountDto> dtoList = Arrays.asList(payoutAccountDto, payoutAccountDto);
@@ -91,7 +91,7 @@ class PayoutAccountMapperTest {
 
     @Test
     void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         List<PayoutAccount> entityList = Arrays.asList(payoutAccount, payoutAccount);
         Page<PayoutAccount> entityPage = PaginationTestUtil.buildPageFromList(entityList);
         PayoutAccountDto payoutAccountDto = PayoutAccountTestUtil.buildPayoutAccountDto();

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/service/impl/BalanceOperationServiceImplTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/service/impl/BalanceOperationServiceImplTest.java
@@ -79,9 +79,10 @@ class BalanceOperationServiceImplTest {
         LocalDateTime startTime = BalanceOperationTestUtil.TIME_BEFORE_CREATION;
         LocalDateTime endTime = BalanceOperationTestUtil.TIME_AFTER_CREATION;
 
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         BalanceOperation operation =
-                BalanceOperationTestUtil.getBalanceOperationBuilder()
+                BalanceOperationTestUtil.buildDefaultBalanceOperation()
+                        .toBuilder()
                         .payoutAccount(payoutAccount)
                         .build();
         BalanceOperationDto operationDto = BalanceOperationTestUtil.buildBalanceOperationDto();
@@ -117,11 +118,12 @@ class BalanceOperationServiceImplTest {
 
     @Test
     void processDeposit_ShouldProcessDepositSuccessfully_WhenValidAmount() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         BalanceOperationAddingDto operationAddingDto =
                 BalanceOperationTestUtil.buildBalanceOperationAddingDto(BalanceOperationTestUtil.DEPOSIT_AMOUNT);
         BalanceOperation operation =
-                BalanceOperationTestUtil.getBalanceOperationBuilder()
+                BalanceOperationTestUtil.buildDefaultBalanceOperation()
+                        .toBuilder()
                         .payoutAccount(payoutAccount)
                         .build();
         BalanceOperationDto operationDto = BalanceOperationTestUtil.buildBalanceOperationDto();
@@ -142,7 +144,7 @@ class BalanceOperationServiceImplTest {
 
     @Test
     void processDeposit_ShouldThrowBadRequestException_WhenInvalidAmount() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         BalanceOperationAddingDto operationAddingDto =
                 BalanceOperationTestUtil.buildBalanceOperationAddingDto(BalanceOperationTestUtil.WITHDRAW_AMOUNT);
 
@@ -160,10 +162,11 @@ class BalanceOperationServiceImplTest {
 
     @Test
     void processWithdraw_ShouldProcessWithdrawSuccessfully_WhenValidAmountAndSufficientFunds() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Long currentBalance = PayoutAccountTestUtil.COMPUTED_BALANCE;
         BalanceOperation operation =
-                BalanceOperationTestUtil.getBalanceOperationBuilder()
+                BalanceOperationTestUtil.buildDefaultBalanceOperation()
+                        .toBuilder()
                         .payoutAccount(payoutAccount)
                         .build();
         BalanceOperationAddingDto operationAddingDto =
@@ -193,7 +196,7 @@ class BalanceOperationServiceImplTest {
 
     @Test
     void processWithdraw_ShouldThrowBadRequestException_WhenInsufficientFunds() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Long currentBalance = PayoutAccountTestUtil.COMPUTED_BALANCE;
         Long withdrawAmount = 2 * BalanceOperationTestUtil.WITHDRAW_AMOUNT;
         BalanceOperationAddingDto operationAddingDto =
@@ -215,7 +218,7 @@ class BalanceOperationServiceImplTest {
 
     @Test
     void processWithdraw_ShouldThrowResourceNotFoundException_WhenStripeAccountNotFound() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         BalanceOperationAddingDto operationAddingDto =
                 BalanceOperationTestUtil.buildBalanceOperationAddingDto(BalanceOperationTestUtil.WITHDRAW_AMOUNT);
         Long currentBalance = PayoutAccountTestUtil.COMPUTED_BALANCE;
@@ -236,7 +239,7 @@ class BalanceOperationServiceImplTest {
 
     @Test
     void getAccountBalance_ShouldReturnComputedBalance_WhenCalledWithValidParameters() {
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Long balance = PayoutAccountTestUtil.COMPUTED_BALANCE;
 
         when(balanceOperationRepository.getBalance(payoutAccount))

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/service/impl/PayoutAccountServiceImplTest.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/unit/service/impl/PayoutAccountServiceImplTest.java
@@ -86,7 +86,7 @@ class PayoutAccountServiceImplTest {
         PayoutAccountSortField sortBy = PayoutAccountSortField.ID;
         Sort.Direction sortOrder = Sort.Direction.ASC;
 
-        PayoutAccount account = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount account = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         PayoutAccountDto accountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
 
         PageRequest pageRequest = PaginationTestUtil.buildPageRequest(offset, limit, sortBy.getValue(), sortOrder);
@@ -120,7 +120,7 @@ class PayoutAccountServiceImplTest {
 
     @Test
     void getPayoutAccount_ShouldReturnPayoutAccount_WhenPayoutAccountFound() {
-        PayoutAccount account = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount account = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         PayoutAccountDto accountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
 
         when(payoutAccountRepository.findById(account.getId()))
@@ -140,7 +140,7 @@ class PayoutAccountServiceImplTest {
 
     @Test
     void getPayoutAccount_ShouldThrowResourceNotFoundException_WhenPayoutAccountNotFound() {
-        PayoutAccount account = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount account = PayoutAccountTestUtil.buildDefaultPayoutAccount();
 
         when(payoutAccountRepository.findById(account.getId()))
                 .thenReturn(Optional.empty());
@@ -155,7 +155,7 @@ class PayoutAccountServiceImplTest {
 
     @Test
     void createPayoutAccount_ShouldReturnPayoutAccount_WhenPayoutAccountIsValid() {
-        PayoutAccount account = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount account = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         PayoutAccountDto accountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
         PayoutAccountAddingDto addingDto = PayoutAccountTestUtil.buildPayoutAccountAddingDto();
         Account stripeAccount = StripeTestUtil.buildStripeAccount();
@@ -221,7 +221,7 @@ class PayoutAccountServiceImplTest {
 
     @Test
     void updatePayoutAccount_ShouldUpdateStripeAccountId_WhenPayoutAndStripeAccountsExist() {
-        PayoutAccount account = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount account = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         Account stripeAccount = StripeTestUtil.buildStripeAccount();
         PayoutAccountDto accountDto = PayoutAccountTestUtil.buildPayoutAccountDto();
 
@@ -381,7 +381,7 @@ class PayoutAccountServiceImplTest {
         LocalDateTime startTime = BalanceOperationTestUtil.TIME_BEFORE_CREATION;
         LocalDateTime endTime = BalanceOperationTestUtil.TIME_AFTER_CREATION;
 
-        PayoutAccount payoutAccount = PayoutAccountTestUtil.getPayoutAccountBuilder().build();
+        PayoutAccount payoutAccount = PayoutAccountTestUtil.buildDefaultPayoutAccount();
         BalanceOperationDto operationDto = BalanceOperationTestUtil.buildBalanceOperationDto();
 
         Page<BalanceOperationDto> operationDtoPage = PaginationTestUtil.buildPageFromSingleElement(operationDto);

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/util/BalanceOperationTestUtil.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/util/BalanceOperationTestUtil.java
@@ -25,14 +25,15 @@ public final class BalanceOperationTestUtil {
     public static final LocalDateTime TIME_INTERVAL_BEFORE_CREATION_START = CREATED_AT.minusDays(5);
     public static final LocalDateTime TIME_INTERVAL_BEFORE_CREATION_END = CREATED_AT.minusDays(1);
 
-    public static BalanceOperation.BalanceOperationBuilder getBalanceOperationBuilder() {
+    public static BalanceOperation buildDefaultBalanceOperation() {
         return BalanceOperation.builder()
                 .id(ID)
                 .payoutAccount(null)
                 .amount(DEPOSIT_AMOUNT)
                 .type(TYPE)
                 .transcript(TRANSCRIPT)
-                .createdAt(CREATED_AT);
+                .createdAt(CREATED_AT)
+                .build();
     }
 
     public static BalanceOperationDto buildBalanceOperationDto() {

--- a/payout-service/src/test/java/com/cabaggregator/payoutservice/util/PayoutAccountTestUtil.java
+++ b/payout-service/src/test/java/com/cabaggregator/payoutservice/util/PayoutAccountTestUtil.java
@@ -19,16 +19,18 @@ public final class PayoutAccountTestUtil {
 
     public static final UUID NOT_EXISTING_ID = UUID.fromString("f47ac10b-58cc-4372-a567-0e02b2c3d479");
 
-    public static PayoutAccount.PayoutAccountBuilder getPayoutAccountBuilder() {
+    public static PayoutAccount buildDefaultPayoutAccount() {
         return PayoutAccount.builder()
                 .id(ID)
                 .stripeAccountId(StripeTestUtil.STRIPE_ACCOUNT_ID)
                 .createdAt(CREATED_AT)
-                .active(ACTIVE);
+                .active(ACTIVE)
+                .build();
     }
 
     public static PayoutAccount getNotExistingPayoutAccount() {
-        return getPayoutAccountBuilder()
+        return buildDefaultPayoutAccount()
+                .toBuilder()
                 .id(NOT_EXISTING_ID)
                 .stripeAccountId(StripeTestUtil.NOT_EXISTING_STRIPE_ACCOUNT_ID)
                 .build();

--- a/price-calculation-service/src/main/java/com/cabaggregator/pricecalculationservice/entity/RideFare.java
+++ b/price-calculation-service/src/main/java/com/cabaggregator/pricecalculationservice/entity/RideFare.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "ride_fares")

--- a/price-calculation-service/src/main/java/com/cabaggregator/pricecalculationservice/entity/WeatherCoefficient.java
+++ b/price-calculation-service/src/main/java/com/cabaggregator/pricecalculationservice/entity/WeatherCoefficient.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "weather_coefficients")

--- a/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/DemandServiceImplTest.java
+++ b/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/DemandServiceImplTest.java
@@ -62,7 +62,6 @@ class DemandServiceImplTest {
         String gridCell = GeoGridTestUtil.GRID_CELL;
         ObjectId rideId = PriceCalculationTestUtil.RIDE_ID;
 
-
         when(cellDemandStore.get(gridCell))
                 .thenReturn(Optional.of(currentOrders));
         when(cellRideStore.exists(gridCell, rideId))

--- a/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/PriceCalculationServiceImplTest.java
+++ b/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/PriceCalculationServiceImplTest.java
@@ -48,15 +48,15 @@ class PriceCalculationServiceImplTest {
 
     @Test
     void calculatePrice_ShouldReturnPriceResponse_WhenAllPricePolicyFound() {
-        PriceCalculationRequest request = PriceCalculationTestUtil.getPriceCalculationRequest();
+        PriceCalculationRequest request = PriceCalculationTestUtil.buildPriceCalculationRequest();
         List<Double> coordinates = request.pickUpCoordinates();
         String gridCell = GeoGridTestUtil.GRID_CELL;
-        RideFare rideFare = RideFareTestUtil.getRideFareBuilder().build();
+        RideFare rideFare = RideFareTestUtil.buildDefaultRideFare();
         DemandCoefficient demandCoefficient =
                 DemandCoefficientTestUtil.buildStandardDemandCoefficient();
         WeatherCoefficient weatherCoefficient =
-                WeatherCoefficientTestUtil.getWeatherCoefficientBuilder().build();
-        PriceResponse priceResponse = PriceCalculationTestUtil.getPriceResponse();
+                WeatherCoefficientTestUtil.buildDefaultWeatherCoefficient();
+        PriceResponse priceResponse = PriceCalculationTestUtil.buildPriceResponse();
 
         when(geoGridService.calculateGridCell(coordinates.get(1), coordinates.get(0)))
                 .thenReturn(gridCell);

--- a/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/RideFareServiceImplTest.java
+++ b/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/RideFareServiceImplTest.java
@@ -30,7 +30,7 @@ class RideFareServiceImplTest {
 
     @Test
     void getRideFare_ShouldReturnRideFare_WhenRideFareFound() {
-        RideFare rideFare = RideFareTestUtil.getRideFareBuilder().build();
+        RideFare rideFare = RideFareTestUtil.buildDefaultRideFare();
 
         when(rideFareRepository.findById(rideFare.getName()))
                 .thenReturn(Optional.of(rideFare));
@@ -46,7 +46,7 @@ class RideFareServiceImplTest {
 
     @Test
     void getRideFare_ShouldThrowInternalErrorException_WhenRideFareNotFound() {
-        RideFare rideFare = RideFareTestUtil.getRideFareBuilder().build();
+        RideFare rideFare = RideFareTestUtil.buildDefaultRideFare();
 
         when(rideFareRepository.findById(rideFare.getName()))
                 .thenReturn(Optional.empty());

--- a/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/WeatherCoefficientServiceImplTest.java
+++ b/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/unit/service/impl/WeatherCoefficientServiceImplTest.java
@@ -40,7 +40,7 @@ class WeatherCoefficientServiceImplTest {
     @Test
     void getCurrentWeatherCoefficient_ShouldReturnWeatherCoefficient_WhenWeatherCoefficientFound() {
         String gridCell = GeoGridTestUtil.GRID_CELL;
-        WeatherCoefficient weatherCoefficient = WeatherCoefficientTestUtil.getWeatherCoefficientBuilder().build();
+        WeatherCoefficient weatherCoefficient = WeatherCoefficientTestUtil.buildDefaultWeatherCoefficient();
         Map<String, Object> weatherResponse = WeatherCoefficientTestUtil.WEATHER_RESPONSE;
 
         when(weatherApiClient.getCurrentWeather(gridCell)).thenReturn(weatherResponse);

--- a/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/util/PriceCalculationTestUtil.java
+++ b/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/util/PriceCalculationTestUtil.java
@@ -13,7 +13,7 @@ public final class PriceCalculationTestUtil {
     public static final Long DURATION = 1317L;
     public static final Long PRICE = 2894L;
 
-    public static PriceCalculationRequest getPriceCalculationRequest() {
+    public static PriceCalculationRequest buildPriceCalculationRequest() {
         return new PriceCalculationRequest(
                 RIDE_ID,
                 GeoGridTestUtil.COORDINATES,
@@ -22,7 +22,7 @@ public final class PriceCalculationTestUtil {
                 RideFareTestUtil.NAME);
     }
 
-    public static PriceResponse getPriceResponse() {
+    public static PriceResponse buildPriceResponse() {
         return new PriceResponse(
                 PRICE,
                 DemandCoefficientTestUtil.CURRENT_DEMAND,

--- a/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/util/RideFareTestUtil.java
+++ b/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/util/RideFareTestUtil.java
@@ -10,10 +10,11 @@ public final class RideFareTestUtil {
     public static final Long PRICE_PER_KILOMETER = 130L;
     public static final Long PRICE_PER_MINUTE = 100L;
 
-    public static RideFare.RideFareBuilder getRideFareBuilder() {
+    public static RideFare buildDefaultRideFare() {
         return RideFare.builder()
                 .name(NAME)
                 .pricePerKilometer(PRICE_PER_KILOMETER)
-                .pricePerMinute(PRICE_PER_MINUTE);
+                .pricePerMinute(PRICE_PER_MINUTE)
+                .build();
     }
 }

--- a/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/util/WeatherCoefficientTestUtil.java
+++ b/price-calculation-service/src/test/java/com/cabaggregator/pricecalculationservice/util/WeatherCoefficientTestUtil.java
@@ -17,10 +17,11 @@ public final class WeatherCoefficientTestUtil {
         buildWeatherResponse();
     }
 
-    public static WeatherCoefficient.WeatherCoefficientBuilder getWeatherCoefficientBuilder() {
+    public static WeatherCoefficient buildDefaultWeatherCoefficient() {
         return WeatherCoefficient.builder()
                 .weather(WEATHER)
-                .priceCoefficient(PRICE_COEFFICIENT);
+                .priceCoefficient(PRICE_COEFFICIENT)
+                .build();
     }
 
     private static void buildWeatherResponse() {

--- a/promo-code-service/src/main/java/com/cabaggregator/promocodeservice/entity/PromoCode.java
+++ b/promo-code-service/src/main/java/com/cabaggregator/promocodeservice/entity/PromoCode.java
@@ -15,7 +15,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "promo_codes")

--- a/promo-code-service/src/main/java/com/cabaggregator/promocodeservice/entity/PromoStat.java
+++ b/promo-code-service/src/main/java/com/cabaggregator/promocodeservice/entity/PromoStat.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @Setter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "promo_stats")

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/integration/repository/PromoStatRepositoryTest.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/integration/repository/PromoStatRepositoryTest.java
@@ -45,10 +45,12 @@ public class PromoStatRepositoryTest {
 
     @Test
     void existsByPromoCodeAndUserId_ShouldReturnTrue_WhenPromoStatExists() {
-        final PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        final PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         final PromoCode savedPromoCode = promoCodeRepository.save(promoCode);
 
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().id(null).build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat()
+                .toBuilder()
+                .id(null).build();
         promoStat.setPromoCode(savedPromoCode);
         promoStatRepository.save(promoStat);
 
@@ -59,7 +61,7 @@ public class PromoStatRepositoryTest {
 
     @Test
     void existsByPromoCodeAndUserId_ShouldReturnFalse_WhenPromoStatDoesNotExist() {
-        final PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        final PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
 
         boolean result = promoStatRepository.existsByPromoCodeAndUserId(promoStat.getPromoCode(), promoStat.getUserId());
 

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/core/mapper/PromoCodeMapperTest.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/core/mapper/PromoCodeMapperTest.java
@@ -25,7 +25,7 @@ class PromoCodeMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         PromoCodeDto promoCodeDto = PromoCodeTestUtil.buildPromoCodeDto();
 
         PromoCodeDto actual = mapper.entityToDto(promoCode);
@@ -42,7 +42,7 @@ class PromoCodeMapperTest {
 
     @Test
     void updateEntityFromDto_ShouldUpdateEntity_WhenDtoIsNotNull() {
-        PromoCode actual = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode actual = PromoCodeTestUtil.buildDefaultPromoCode();
         PromoCodeUpdatingDto promoCodeUpdatingDto = PromoCodeTestUtil.buildPromoCodeUpdatingDto();
 
         mapper.updateEntityFromDto(promoCodeUpdatingDto, actual);
@@ -82,7 +82,7 @@ class PromoCodeMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         PromoCodeDto promoCodeDto = PromoCodeTestUtil.buildPromoCodeDto();
 
         List<PromoCode> entityList = Arrays.asList(promoCode, promoCode);
@@ -113,7 +113,7 @@ class PromoCodeMapperTest {
 
     @Test
     void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         List<PromoCode> entityList = Arrays.asList(promoCode, promoCode);
         Page<PromoCode> entityPage = PaginationTestUtil.buildPageFromList(entityList);
 

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/core/mapper/PromoStatMapperTest.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/core/mapper/PromoStatMapperTest.java
@@ -23,7 +23,7 @@ class PromoStatMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoStatDto promoStatDto = PromoStatTestUtil.buildPromoStatDto();
 
         PromoStatDto actual = mapper.entityToDto(promoStat);
@@ -57,7 +57,7 @@ class PromoStatMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoStatDto promoStatDto = PromoStatTestUtil.buildPromoStatDto();
 
         List<PromoStat> entityList = Arrays.asList(promoStat, promoStat);
@@ -88,7 +88,7 @@ class PromoStatMapperTest {
 
     @Test
     void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         List<PromoStat> entityList = Arrays.asList(promoStat, promoStat);
         Page<PromoStat> entityPage = PaginationTestUtil.buildPageFromList(entityList);
 

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/service/impl/PromoCodeServiceImplTest.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/service/impl/PromoCodeServiceImplTest.java
@@ -66,7 +66,7 @@ class PromoCodeServiceImplTest {
         PromoCodeSortField sortBy = PromoCodeSortField.LIMIT;
         Sort.Direction sortOrder = Sort.Direction.ASC;
 
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         PromoCodeDto promoCodeDto = PromoCodeTestUtil.buildPromoCodeDto();
 
         PageRequest pageRequest = PaginationTestUtil.buildPageRequest(offset, limit, sortBy.getValue(), sortOrder);
@@ -99,7 +99,7 @@ class PromoCodeServiceImplTest {
 
     @Test
     void getPromoCode_ShouldReturnPromoCode_WhenPromoCodeFound() {
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         PromoCodeDto promoCodeDto = PromoCodeTestUtil.buildPromoCodeDto();
 
         when(promoCodeRepository.findById(promoCode.getValue()))
@@ -119,7 +119,7 @@ class PromoCodeServiceImplTest {
 
     @Test
     void getPromoCode_ShouldThrowResourceNotFoundException_WhenPromoCodeNotFound() {
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
 
         when(promoCodeRepository.findById(promoCode.getValue()))
                 .thenReturn(Optional.empty());
@@ -169,7 +169,7 @@ class PromoCodeServiceImplTest {
     @Test
     void savePromoCode_ShouldReturnPromoCode_WhenPromoCodeIsValid() {
         PromoCodeAddingDto promoCodeAddingDto = PromoCodeTestUtil.buildPromoCodeAddingDto();
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         PromoCodeDto promoCodeDto = PromoCodeTestUtil.buildPromoCodeDto();
 
         doNothing().when(promoCodeValidator).validatePromoCodeUniqueness(promoCodeAddingDto.value());
@@ -196,7 +196,7 @@ class PromoCodeServiceImplTest {
 
     @Test
     void updatePromoCode_ShouldReturnPromoCode_WhenPromoCodeFound() {
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
         PromoCodeDto promoCodeDto = PromoCodeTestUtil.buildPromoCodeDto();
         PromoCodeUpdatingDto promoCodeUpdatingDto = PromoCodeTestUtil.buildPromoCodeUpdatingDto();
 

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/service/impl/PromoStatServiceImplTest.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/service/impl/PromoStatServiceImplTest.java
@@ -73,7 +73,7 @@ class PromoStatServiceImplTest {
         PromoStatSortField sortBy = PromoStatSortField.USER_ID;
         Sort.Direction sortOrder = Sort.Direction.ASC;
 
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoStatDto promoStatDto = PromoStatTestUtil.buildPromoStatDto();
 
         PageRequest pageRequest = PaginationTestUtil.buildPageRequest(offset, limit, sortBy.getValue(), sortOrder);
@@ -106,9 +106,7 @@ class PromoStatServiceImplTest {
 
     @Test
     void getPromoStat_ShouldReturnPromoStat_WhenPromoStatFound() {
-        PromoStat promoStat =
-                PromoStatTestUtil.getPromoStatBuilder()
-                        .build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoStatDto promoStatDto = PromoStatTestUtil.buildPromoStatDto();
 
         when(promoStatRepository.findById(promoStat.getId()))
@@ -128,9 +126,7 @@ class PromoStatServiceImplTest {
 
     @Test
     void getPromoStat_ShouldThrowResourceNotFoundException_WhenPromoStatNotFound() {
-        PromoStat promoStat =
-                PromoStatTestUtil.getPromoStatBuilder()
-                        .build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
 
         when(promoStatRepository.findById(promoStat.getId()))
                 .thenReturn(Optional.empty());
@@ -145,7 +141,7 @@ class PromoStatServiceImplTest {
 
     @Test
     void savePromoStat_ShouldReturnPromoStat_WhenPromoCodeIsValidAndItExists() {
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoCode promoCode = promoStat.getPromoCode();
         PromoStatDto promoStatDto = PromoStatTestUtil.buildPromoStatDto();
         PromoStatAddingDto promoStatAddingDto = PromoStatTestUtil.buildPromoStatAddingDto();
@@ -186,7 +182,7 @@ class PromoStatServiceImplTest {
 
     @Test
     void savePromoStat_ShouldThrowBadRequestException_WhenPromoCodeExistsAndAlreadyHasBeenApplied() {
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoCode promoCode = promoStat.getPromoCode();
         PromoStatAddingDto promoStatAddingDto = PromoStatTestUtil.buildPromoStatAddingDto();
 
@@ -208,7 +204,7 @@ class PromoStatServiceImplTest {
 
     @Test
     void savePromoStat_ShouldThrowBadRequestException_WhenPromoCodeExistsAndHasExpired() {
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoCode promoCode = promoStat.getPromoCode();
         PromoStatAddingDto promoStatAddingDto = PromoStatTestUtil.buildPromoStatAddingDto();
 
@@ -232,7 +228,7 @@ class PromoStatServiceImplTest {
 
     @Test
     void savePromoStat_ShouldThrowBadRequestException_WhenPromoCodeExistsAndItsApplicationLimitHasReached() {
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         PromoCode promoCode = promoStat.getPromoCode();
         PromoStatAddingDto promoStatAddingDto = PromoStatTestUtil.buildPromoStatAddingDto();
 

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/validator/PromoStatValidatorTest.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/unit/validator/PromoStatValidatorTest.java
@@ -32,8 +32,8 @@ class PromoStatValidatorTest {
 
     @Test
     void validatePromoCodeApplication_ShouldThrowBadRequestException_WhenPromoCodeAlreadyApplied() {
-        PromoCode promoCode = PromoCodeTestUtil.getPromoCodeBuilder().build();
-        PromoStat promoStat = PromoStatTestUtil.getPromoStatBuilder().build();
+        PromoCode promoCode = PromoCodeTestUtil.buildDefaultPromoCode();
+        PromoStat promoStat = PromoStatTestUtil.buildDefaultPromoStat();
         promoStat.setPromoCode(promoCode);
 
         PromoCode code = promoStat.getPromoCode();
@@ -49,7 +49,7 @@ class PromoStatValidatorTest {
 
     @Test
     void validatePromoCodeApplication_ShouldNotThrowException_WhenPromoCodeIsNotApplied() {
-        PromoCode code = PromoCodeTestUtil.getPromoCodeBuilder().build();
+        PromoCode code = PromoCodeTestUtil.buildDefaultPromoCode();
         UUID userId = PromoStatTestUtil.USER_ID;
 
         when(promoStatRepository.existsByPromoCodeAndUserId(code, userId)).thenReturn(false);

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/util/PromoCodeTestUtil.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/util/PromoCodeTestUtil.java
@@ -22,12 +22,13 @@ public final class PromoCodeTestUtil {
 
     public static final String NOT_EXISTING_CODE = "NOT_EXISTING_CODE";
 
-    public static PromoCode.PromoCodeBuilder getPromoCodeBuilder() {
+    public static PromoCode buildDefaultPromoCode() {
         return PromoCode.builder()
                 .value(VALUE)
                 .discountPercentage(DISCOUNT_PERCENTAGE)
                 .endDate(END_DATE)
-                .limit(LIMIT);
+                .limit(LIMIT)
+                .build();
     }
 
     public static PromoCodeDto buildPromoCodeDto() {

--- a/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/util/PromoStatTestUtil.java
+++ b/promo-code-service/src/test/java/com/cabaggregator/promocodeservice/util/PromoStatTestUtil.java
@@ -13,11 +13,12 @@ public final class PromoStatTestUtil {
     public static final Long ID = 1L;
     public static final UUID USER_ID = UUID.fromString("4665e57c-884a-433d-8fd2-55078f29eab9");
 
-    public static PromoStat.PromoStatBuilder getPromoStatBuilder() {
+    public static PromoStat buildDefaultPromoStat() {
         return PromoStat.builder()
                 .id(ID)
                 .userId(USER_ID)
-                .promoCode(PromoCodeTestUtil.getPromoCodeBuilder().build());
+                .promoCode(PromoCodeTestUtil.buildDefaultPromoCode())
+                .build();
     }
 
     public static PromoStatDto buildPromoStatDto() {

--- a/rating-service/src/main/java/com/cabaggregator/ratingservice/entity/DriverRate.java
+++ b/rating-service/src/main/java/com/cabaggregator/ratingservice/entity/DriverRate.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Document("driver_rate")

--- a/rating-service/src/main/java/com/cabaggregator/ratingservice/entity/PassengerRate.java
+++ b/rating-service/src/main/java/com/cabaggregator/ratingservice/entity/PassengerRate.java
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.util.UUID;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Document("passenger_rate")

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/integration/repository/DriverRateRepositoryTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/integration/repository/DriverRateRepositoryTest.java
@@ -39,7 +39,7 @@ class DriverRateRepositoryTest extends AbstractIntegrationTest {
         int pageNumber = 0;
         int pageSize = 10;
         int expectedContentSize = 1;
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
 
         Page<DriverRate> actual =
                 driverRateRepository.findAllByDriverId(
@@ -67,7 +67,7 @@ class DriverRateRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void findByDriverIdAndRideId_ShouldReturnDriverRate_WhenDriverRateExists() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
 
         Optional<DriverRate> actual = driverRateRepository.findByDriverIdAndRideId(
                 driverRate.getDriverId(), driverRate.getRideId());
@@ -87,7 +87,7 @@ class DriverRateRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void existsByDriverIdAndRideId_ShouldReturnTrue_WhenDriverRateExists() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
 
         boolean actual = driverRateRepository.existsByDriverIdAndRideId(
                 driverRate.getDriverId(), driverRate.getRideId());

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/integration/repository/PassengerRateRepositoryTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/integration/repository/PassengerRateRepositoryTest.java
@@ -39,7 +39,7 @@ class PassengerRateRepositoryTest extends AbstractIntegrationTest {
         int pageNumber = 0;
         int pageSize = 10;
         int expectedContentSize = 1;
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
 
         Page<PassengerRate> actual =
                 passengerRateRepository.findAllByPassengerId(
@@ -67,7 +67,7 @@ class PassengerRateRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void findByPassengerIdAndRideId_ShouldReturnPassengerRate_WhenPassengerRateExists() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
 
         Optional<PassengerRate> actual = passengerRateRepository.findByPassengerIdAndRideId(
                 passengerRate.getPassengerId(), passengerRate.getRideId());
@@ -87,7 +87,7 @@ class PassengerRateRepositoryTest extends AbstractIntegrationTest {
 
     @Test
     void existsByPassengerIdAndRideId_ShouldReturnTrue_WhenPassengerRateExists() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
 
         boolean actual = passengerRateRepository.existsByPassengerIdAndRideId(
                 passengerRate.getPassengerId(), passengerRate.getRideId());

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/core/mapper/DriverRateMapperTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/core/mapper/DriverRateMapperTest.java
@@ -28,7 +28,7 @@ class DriverRateMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         DriverRateDto driverRateDto = DriverRateTestUtil.buildDriverRateDto();
 
         DriverRateDto actual = mapper.entityToDto(driverRate);
@@ -46,7 +46,8 @@ class DriverRateMapperTest {
     @Test
     void updateEntityFromDto_ShouldUpdateEntity_WhenDtoIsNotNull() {
         DriverRate actual =
-                DriverRateTestUtil.getDriverRateBuilder()
+                DriverRateTestUtil.buildDefaultDriverRate()
+                        .toBuilder()
                         .rate(null)
                         .feedbackOptions(null)
                         .build();
@@ -91,7 +92,7 @@ class DriverRateMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         List<DriverRate> entityList = Arrays.asList(driverRate, driverRate);
         DriverRateDto driverRateDto = DriverRateTestUtil.buildDriverRateDto();
         List<DriverRateDto> dtoList = Arrays.asList(driverRateDto, driverRateDto);
@@ -121,7 +122,7 @@ class DriverRateMapperTest {
 
     @Test
     void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         List<DriverRate> entityList = Arrays.asList(driverRate, driverRate);
         Page<DriverRate> entityPage = PaginationTestUtil.buildPageFromList(entityList);
         DriverRateDto driverRateDto = DriverRateTestUtil.buildDriverRateDto();

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/core/mapper/PassengerRateMapperTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/core/mapper/PassengerRateMapperTest.java
@@ -28,7 +28,7 @@ class PassengerRateMapperTest {
 
     @Test
     void entityToDto_ShouldConvertEntityToDto_WhenEntityIsNotNull() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         PassengerRateDto passengerRateDto = PassengerRateTestUtil.buildPassengerRateDto();
 
         PassengerRateDto actual = mapper.entityToDto(passengerRate);
@@ -45,7 +45,7 @@ class PassengerRateMapperTest {
 
     @Test
     void updateEntityFromDto_ShouldUpdateEntity_WhenDtoIsNotNull() {
-        PassengerRate actual = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate actual = PassengerRateTestUtil.buildDefaultPassengerRate();
         PassengerRateSettingDto passengerRateSettingDto = PassengerRateTestUtil.buildPassengerRateSettingDto();
 
         mapper.updateEntityFromDto(passengerRateSettingDto, actual);
@@ -85,7 +85,7 @@ class PassengerRateMapperTest {
 
     @Test
     void entityListToDtoList_ShouldConvertEntityListToDtoList_WhenEntityListIsNotEmpty() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         PassengerRateDto passengerRateDto = PassengerRateTestUtil.buildPassengerRateDto();
         List<PassengerRate> entityList = Arrays.asList(passengerRate, passengerRate);
         List<PassengerRateDto> expectedDtoList = Arrays.asList(passengerRateDto, passengerRateDto);
@@ -115,7 +115,7 @@ class PassengerRateMapperTest {
 
     @Test
     void entityPageToDtoPage_ShouldConvertEntityPageToDtoPage_WhenPageIsNotNull() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         List<PassengerRate> entityList = Arrays.asList(passengerRate, passengerRate);
         Page<PassengerRate> entityPage = PaginationTestUtil.buildPageFromList(entityList);
         PassengerRateDto passengerRateDto = PassengerRateTestUtil.buildPassengerRateDto();

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/service/impl/DriverRateServiceImplTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/service/impl/DriverRateServiceImplTest.java
@@ -72,7 +72,7 @@ class DriverRateServiceImplTest {
         DriverRateSortField sortBy = DriverRateSortField.ID;
         Sort.Direction sortOrder = Sort.Direction.ASC;
 
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         DriverRateDto driverRateDto = DriverRateTestUtil.buildDriverRateDto();
 
@@ -128,7 +128,7 @@ class DriverRateServiceImplTest {
 
     @Test
     void getDriverRate_ShouldReturnDriverRate_WhenDriverRateFound() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         ObjectId rideId = driverRate.getRideId();
         DriverRateDto driverRateDto = DriverRateTestUtil.buildDriverRateDto();
@@ -152,7 +152,7 @@ class DriverRateServiceImplTest {
 
     @Test
     void getDriverRate_ShouldThrowForbiddenException_WhenUserIsAnotherDriver() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         ObjectId rideId = driverRate.getRideId();
 
@@ -170,7 +170,7 @@ class DriverRateServiceImplTest {
 
     @Test
     void getDriverRate_ShouldThrowResourceNotFoundException_WhenDriverRateNotFound() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         ObjectId rideId = driverRate.getRideId();
 
@@ -192,7 +192,7 @@ class DriverRateServiceImplTest {
         DriverRateAddingDto driverRateAddingDto = DriverRateTestUtil.buildDriverRateAddingDto();
         UUID driverId = driverRateAddingDto.driverId();
         ObjectId rideId = driverRateAddingDto.rideId();
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         DriverRateDto driverRateDto = DriverRateTestUtil.buildDriverRateDto();
 
         doNothing().when(driverRateValidator).validateDriverRateUniqueness(driverId, rideId);
@@ -237,7 +237,7 @@ class DriverRateServiceImplTest {
     @Test
     void setDriverRate_ShouldReturnDriverRate_WhenDriverRateFoundAndIsNotSet() {
         DriverRateSettingDto driverRateSettingDto = DriverRateTestUtil.buildDriverRateSettingDto();
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         ObjectId rideId = driverRate.getRideId();
         DriverRateDto driverRateDto = DriverRateTestUtil.buildDriverRateDto();
@@ -265,7 +265,7 @@ class DriverRateServiceImplTest {
     @Test
     void setDriverRate_ShouldThrowResourceNotFoundException_WhenDriverRateNotFound() {
         DriverRateSettingDto driverRateSettingDto = DriverRateTestUtil.buildDriverRateSettingDto();
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         ObjectId rideId = driverRate.getRideId();
 
@@ -284,7 +284,7 @@ class DriverRateServiceImplTest {
     @Test
     void setDriverRate_ShouldThrowForbiddenException_WhenUserIsNotRideParticipant() {
         DriverRateSettingDto driverRateSettingDto = DriverRateTestUtil.buildDriverRateSettingDto();
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         ObjectId rideId = driverRate.getRideId();
 
@@ -307,7 +307,7 @@ class DriverRateServiceImplTest {
     @Test
     void setDriverRate_ShouldThrowBadRequestException_WhenDriverRateAlreadySet() {
         DriverRateSettingDto driverRateSettingDto = DriverRateTestUtil.buildDriverRateSettingDto();
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
         UUID driverId = driverRate.getDriverId();
         ObjectId rideId = driverRate.getRideId();
 

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/service/impl/PassengerRateServiceImplTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/service/impl/PassengerRateServiceImplTest.java
@@ -72,7 +72,7 @@ class PassengerRateServiceImplTest {
         PassengerRateSortField sortBy = PassengerRateSortField.ID;
         Sort.Direction sortOrder = Sort.Direction.ASC;
 
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         PassengerRateDto passengerRateDto = PassengerRateTestUtil.buildPassengerRateDto();
 
@@ -128,7 +128,7 @@ class PassengerRateServiceImplTest {
 
     @Test
     void getPassengerRate_ShouldReturnPassengerRate_WhenPassengerRateFound() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         ObjectId rideId = passengerRate.getRideId();
         PassengerRateDto passengerRateDto = PassengerRateTestUtil.buildPassengerRateDto();
@@ -152,7 +152,7 @@ class PassengerRateServiceImplTest {
 
     @Test
     void getPassengerRate_ShouldThrowForbiddenException_WhenUserIsAnotherPassenger() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         ObjectId rideId = passengerRate.getRideId();
 
@@ -170,7 +170,7 @@ class PassengerRateServiceImplTest {
 
     @Test
     void getPassengerRate_ShouldThrowResourceNotFoundException_WhenPassengerRateNotFound() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         ObjectId rideId = passengerRate.getRideId();
 
@@ -192,7 +192,7 @@ class PassengerRateServiceImplTest {
         PassengerRateAddingDto passengerRateAddingDto = PassengerRateTestUtil.buildPassengerRateAddingDto();
         UUID passengerId = passengerRateAddingDto.passengerId();
         ObjectId rideId = passengerRateAddingDto.rideId();
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         PassengerRateDto passengerRateDto = PassengerRateTestUtil.buildPassengerRateDto();
 
         doNothing().when(passengerRateValidator).validatePassengerRateUniqueness(passengerId, rideId);
@@ -237,7 +237,7 @@ class PassengerRateServiceImplTest {
     @Test
     void setPassengerRate_ShouldReturnPassengerRate_WhenPassengerRateFoundAndIsNotSet() {
         PassengerRateSettingDto passengerRateSettingDto = PassengerRateTestUtil.buildPassengerRateSettingDto();
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         ObjectId rideId = passengerRate.getRideId();
         PassengerRateDto passengerRateDto = PassengerRateTestUtil.buildPassengerRateDto();
@@ -265,7 +265,7 @@ class PassengerRateServiceImplTest {
     @Test
     void setPassengerRate_ShouldThrowResourceNotFoundException_WhenPassengerRateNotFound() {
         PassengerRateSettingDto passengerRateSettingDto = PassengerRateTestUtil.buildPassengerRateSettingDto();
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         ObjectId rideId = passengerRate.getRideId();
 
@@ -284,7 +284,7 @@ class PassengerRateServiceImplTest {
     @Test
     void setPassengerRate_ShouldThrowForbiddenException_WhenUserIsNotRideParticipant() {
         PassengerRateSettingDto passengerRateSettingDto = PassengerRateTestUtil.buildPassengerRateSettingDto();
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         ObjectId rideId = passengerRate.getRideId();
 
@@ -307,7 +307,7 @@ class PassengerRateServiceImplTest {
     @Test
     void setPassengerRate_ShouldThrowBadRequestException_WhenPassengerRateAlreadySet() {
         PassengerRateSettingDto passengerRateSettingDto = PassengerRateTestUtil.buildPassengerRateSettingDto();
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
         UUID passengerId = passengerRate.getPassengerId();
         ObjectId rideId = passengerRate.getRideId();
 

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/validator/DriverRateValidatorTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/validator/DriverRateValidatorTest.java
@@ -62,7 +62,7 @@ class DriverRateValidatorTest {
 
     @Test
     void validateDriverRateSetting_ShouldThrowBadRequestException_WhenDriverRateAlreadySet() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
 
         assertThatThrownBy(
                 () -> driverRateValidator.validateDriverRateSetting(driverRate))
@@ -74,7 +74,8 @@ class DriverRateValidatorTest {
     @Test
     void validateDriverRateSetting_ShouldNotThrowException_WhenDriverRateNotSet() {
         DriverRate driverRate =
-                DriverRateTestUtil.getDriverRateBuilder()
+                DriverRateTestUtil.buildDefaultDriverRate()
+                        .toBuilder()
                         .rate(null)
                         .build();
 
@@ -87,7 +88,7 @@ class DriverRateValidatorTest {
 
     @Test
     void validatePassengerParticipation_ShouldThrowForbiddenException_WhenUserIsNotRideParticipant() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
 
         try (MockedStatic<SecurityUtil> mockedStatic = mockStatic(SecurityUtil.class)) {
             mockedStatic.when(SecurityUtil::getUserIdFromSecurityContext)
@@ -104,7 +105,7 @@ class DriverRateValidatorTest {
 
     @Test
     void validatePassengerParticipation_ShouldNotThrowException_WhenUserIsRideParticipant() {
-        DriverRate driverRate = DriverRateTestUtil.getDriverRateBuilder().build();
+        DriverRate driverRate = DriverRateTestUtil.buildDefaultDriverRate();
 
         try (MockedStatic<SecurityUtil> mockedStatic = mockStatic(SecurityUtil.class)) {
             mockedStatic.when(SecurityUtil::getUserIdFromSecurityContext)

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/validator/PassengerRateValidatorTest.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/unit/validator/PassengerRateValidatorTest.java
@@ -62,7 +62,7 @@ class PassengerRateValidatorTest {
 
     @Test
     void validatePassengerRateSetting_ShouldThrowBadRequestException_WhenPassengerRateAlreadySet() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
 
         assertThatThrownBy(
                 () -> passengerRateValidator.validatePassengerRateSetting(passengerRate))
@@ -74,7 +74,8 @@ class PassengerRateValidatorTest {
     @Test
     void validatePassengerRateSetting_ShouldNotThrowException_WhenPassengerRateNotSet() {
         PassengerRate passengerRate =
-                PassengerRateTestUtil.getPassengerRateBuilder()
+                PassengerRateTestUtil.buildDefaultPassengerRate()
+                        .toBuilder()
                         .rate(null)
                         .build();
 
@@ -87,7 +88,7 @@ class PassengerRateValidatorTest {
 
     @Test
     void validateDriverParticipation_ShouldThrowForbiddenException_WhenUserIsNotRideParticipant() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
 
         try (MockedStatic<SecurityUtil> mockedStatic = mockStatic(SecurityUtil.class)) {
             mockedStatic.when(SecurityUtil::getUserIdFromSecurityContext)
@@ -104,7 +105,7 @@ class PassengerRateValidatorTest {
 
     @Test
     void validateDriverParticipation_ShouldNotThrowException_WhenUserIsRideParticipant() {
-        PassengerRate passengerRate = PassengerRateTestUtil.getPassengerRateBuilder().build();
+        PassengerRate passengerRate = PassengerRateTestUtil.buildDefaultPassengerRate();
 
         try (MockedStatic<SecurityUtil> mockedStatic = mockStatic(SecurityUtil.class)) {
             mockedStatic.when(SecurityUtil::getUserIdFromSecurityContext)

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/util/DriverRateTestUtil.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/util/DriverRateTestUtil.java
@@ -27,14 +27,15 @@ public final class DriverRateTestUtil {
     public static final ObjectId NOT_EXISTING_RIDE_ID = new ObjectId("000000000000000000000000");
     public static final UUID NOT_EXISTING_DRIVER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
 
-    public static DriverRate.DriverRateBuilder getDriverRateBuilder() {
+    public static DriverRate buildDefaultDriverRate() {
         return DriverRate.builder()
                 .id(ID)
                 .rideId(RIDE_ID)
                 .driverId(DRIVER_ID)
                 .passengerId(PASSENGER_ID)
                 .rate(RATE)
-                .feedbackOptions(FEEDBACK_OPTIONS);
+                .feedbackOptions(FEEDBACK_OPTIONS)
+                .build();
     }
 
     public static DriverRateDto buildDriverRateDto() {

--- a/rating-service/src/test/java/com/cabaggregator/ratingservice/util/PassengerRateTestUtil.java
+++ b/rating-service/src/test/java/com/cabaggregator/ratingservice/util/PassengerRateTestUtil.java
@@ -23,13 +23,14 @@ public final class PassengerRateTestUtil {
     public static final ObjectId NOT_EXISTING_RIDE_ID = new ObjectId("000000000000000000000000");
     public static final UUID NOT_EXISTING_PASSENGER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
-    public static PassengerRate.PassengerRateBuilder getPassengerRateBuilder() {
+    public static PassengerRate buildDefaultPassengerRate() {
         return PassengerRate.builder()
                 .id(ID)
                 .rideId(RIDE_ID)
                 .driverId(DRIVER_ID)
                 .passengerId(PASSENGER_ID)
-                .rate(RATE);
+                .rate(RATE)
+                .build();
     }
 
     public static PassengerRateDto buildPassengerRateDto() {


### PR DESCRIPTION
**This pull request adds code refactoring of building default entities in service unit tests.**

Methods like

Entity.EntityBuilder getEntityBuilder()
was replaced with
Entity buildDefaultEntity()
and 
@Builder(toBuilder = true)
class Entity {
...
}
