### PR TITLE
fix(rating-service): enable mongodb transactions

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,30 @@ services:
     volumes:
       - ride-database2_data:/data/db
 
+  rating-database1:
+    build:
+      context: .
+    container_name: rating-database1
+    image: mongo:7.0
+    restart: always
+    command: mongod --replSet rs1 --bind_ip_all
+    ports:
+      - "27019:27018"
+    volumes:
+      - rating-database1_data:/data/db
+
+  rating-database2:
+    build:
+      context: .
+    container_name: rating-database2
+    image: mongo:7.0
+    restart: always
+    command: mongod --replSet rs1 --bind_ip_all
+    ports:
+      - "27020:27018"
+    volumes:
+      - rating-database2_data:/data/db
+
   zookeeper:
     image: zookeeper:3.7.0
     container_name: zookeeper

--- a/rating-service/src/main/java/com/cabaggregator/ratingservice/config/MongodbConfig.java
+++ b/rating-service/src/main/java/com/cabaggregator/ratingservice/config/MongodbConfig.java
@@ -1,0 +1,17 @@
+package com.cabaggregator.ratingservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class MongodbConfig {
+
+    @Bean
+    public MongoTransactionManager transactionManager(MongoDatabaseFactory factory) {
+        return new MongoTransactionManager(factory);
+    }
+}

--- a/rating-service/src/main/resources/application.yml
+++ b/rating-service/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
       uri: mongodb://${DB_HOSTPORT:localhost:27017}/${DB_NAME:rating_database}
       username: ${DB_USERNAME:mongo}
       password: ${DB_PASSWORD:root}
+      replica-set-name: ${DB_REPLICA_SET_NAME:rs1}
+      database: ${DB_NAME:rating_database}
 mongock:
   migration-scan-package: com.cabaggregator.ratingservice.migrations
   enabled: true


### PR DESCRIPTION
**This pull request enables transaction mechanism in mongodb.**

_Added features:_
1. Mongodb:
- Added mongodb replica set for rating database to be able to use mongodb transactions
2. Configs:
- Added Mongodb application config to enable transaction management in SpringBoot app