### PR TITLE
feat(user-rating): connect ride & rating services via kafka

### DIFF
--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -31,13 +31,13 @@ app:
   kafka:
     topics:
       passenger:
-        name: ${KAFKA_TOPIC_PASSENGER_NAME:passenger-topic}
-        partitions: ${KAFKA_TOPIC_PASSENGER_PARTITIONS:1}
-        replicas: ${KAFKA_TOPIC_PASSENGER_REPLICAS:1}
+        name: passenger.creation.v1
+        partitions: 1
+        replicas: 1
       driver:
-        name: ${KAFKA_TOPIC_DRIVER_NAME:driver-topic}
-        partitions: ${KAFKA_TOPIC_DRIVER_PARTITIONS:1}
-        replicas: ${KAFKA_TOPIC_DRIVER_REPLICAS:1}
+        name: driver.creation.v1
+        partitions: 1
+        replicas: 1
 server:
   port: ${SERVER_PORT:8081}
   forward-headers-strategy: framework

--- a/driver-service/src/main/resources/application.yml
+++ b/driver-service/src/main/resources/application.yml
@@ -38,6 +38,6 @@ app:
   kafka:
     topics:
       driver:
-        name: ${KAFKA_TOPIC_DRIVER_NAME:driver-topic}
+        name: driver.creation.v1
 server:
   port: ${SERVER_PORT:8083}

--- a/passenger-service/src/main/resources/application.yml
+++ b/passenger-service/src/main/resources/application.yml
@@ -41,6 +41,6 @@ app:
   kafka:
     topics:
       passenger:
-        name: ${KAFKA_TOPIC_PASSENGER_NAME:passenger-topic}
+        name: passenger.creation.v1
 server:
   port: ${SERVER_PORT:8082}

--- a/rating-service/pom.xml
+++ b/rating-service/pom.xml
@@ -36,6 +36,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/rating-service/src/main/java/com/cabaggregator/ratingservice/kafka/consumer/RateConsumer.java
+++ b/rating-service/src/main/java/com/cabaggregator/ratingservice/kafka/consumer/RateConsumer.java
@@ -1,0 +1,36 @@
+package com.cabaggregator.ratingservice.kafka.consumer;
+
+import com.cabaggregator.ratingservice.kafka.dto.RateAddingDto;
+import com.cabaggregator.ratingservice.kafka.mapper.RateAddingDtoMapper;
+import com.cabaggregator.ratingservice.service.DriverRateService;
+import com.cabaggregator.ratingservice.service.PassengerRateService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RateConsumer {
+    private final DriverRateService driverRateService;
+
+    private final PassengerRateService passengerRateService;
+
+    private final RateAddingDtoMapper rateAddingDtoMapper;
+
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = "${app.kafka.topics.rate.name}",
+            groupId = "${spring.kafka.consumer.group-id}")
+    public void consume(Map<String, Object> message) {
+        RateAddingDto rate = objectMapper.convertValue(message, RateAddingDto.class);
+
+        driverRateService.saveDriverRate(
+                rateAddingDtoMapper.toDriverAddingDto(rate));
+        passengerRateService.savePassengerRate(
+                rateAddingDtoMapper.toPassengerAddingDto(rate));
+    }
+}

--- a/rating-service/src/main/java/com/cabaggregator/ratingservice/kafka/dto/RateAddingDto.java
+++ b/rating-service/src/main/java/com/cabaggregator/ratingservice/kafka/dto/RateAddingDto.java
@@ -1,0 +1,15 @@
+package com.cabaggregator.ratingservice.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.bson.types.ObjectId;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class RateAddingDto {
+    private ObjectId rideId;
+    private UUID driverId;
+    private UUID passengerId;
+}

--- a/rating-service/src/main/java/com/cabaggregator/ratingservice/kafka/mapper/RateAddingDtoMapper.java
+++ b/rating-service/src/main/java/com/cabaggregator/ratingservice/kafka/mapper/RateAddingDtoMapper.java
@@ -1,0 +1,14 @@
+package com.cabaggregator.ratingservice.kafka.mapper;
+
+import com.cabaggregator.ratingservice.core.dto.driver.DriverRateAddingDto;
+import com.cabaggregator.ratingservice.core.dto.passenger.PassengerRateAddingDto;
+import com.cabaggregator.ratingservice.kafka.dto.RateAddingDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface RateAddingDtoMapper {
+    DriverRateAddingDto toDriverAddingDto(RateAddingDto rateAddingDto);
+
+    PassengerRateAddingDto toPassengerAddingDto(RateAddingDto rateAddingDto);
+}

--- a/rating-service/src/main/resources/application.yml
+++ b/rating-service/src/main/resources/application.yml
@@ -13,8 +13,27 @@ spring:
       password: ${DB_PASSWORD:root}
       replica-set-name: ${DB_REPLICA_SET_NAME:rs1}
       database: ${DB_NAME:rating_database}
+  kafka:
+    consumer:
+      key-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+      group-id: rate-creation-group
+      properties:
+        spring.json:
+          value.default.type: java.util.Map
+          trusted.packages: '*'
+          use.type.headers: false
+        spring.deserializer:
+          key.delegate.class: org.apache.kafka.common.serialization.StringDeserializer
+          value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
 mongock:
   migration-scan-package: com.cabaggregator.ratingservice.migrations
   enabled: true
+app:
+  kafka:
+    topics:
+      rate:
+        name: ${KAFKA_TOPIC_RATE_NAME:rate-topic}
 server:
   port: ${SERVER_PORT:8086}

--- a/rating-service/src/main/resources/application.yml
+++ b/rating-service/src/main/resources/application.yml
@@ -34,6 +34,6 @@ app:
   kafka:
     topics:
       rate:
-        name: ${KAFKA_TOPIC_RATE_NAME:rate-topic}
+        name: rating.creation.v1
 server:
   port: ${SERVER_PORT:8086}

--- a/ride-service/pom.xml
+++ b/ride-service/pom.xml
@@ -43,6 +43,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/config/KafkaConfig.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/config/KafkaConfig.java
@@ -1,0 +1,23 @@
+package com.cabaggregator.rideservice.kafka.config;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(KafkaTopicConfig.class)
+public class KafkaConfig {
+    private final KafkaTopicConfig kafkaTopicConfig;
+
+    @Bean
+    public NewTopic rateTopic() {
+        var passengerRatesTopic = kafkaTopicConfig.getRate();
+        return new NewTopic(
+                passengerRatesTopic.getName(),
+                passengerRatesTopic.getPartitions(),
+                passengerRatesTopic.getReplicas());
+    }
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/config/KafkaTopicConfig.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/config/KafkaTopicConfig.java
@@ -1,0 +1,24 @@
+package com.cabaggregator.rideservice.kafka.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@AllArgsConstructor
+@ConfigurationProperties(prefix = "app.kafka.topics")
+public class KafkaTopicConfig {
+    private final Topic rate = new Topic();
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Topic {
+        private String name;
+        private int partitions;
+        private short replicas;
+    }
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/dto/RateAddingDto.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/dto/RateAddingDto.java
@@ -1,0 +1,13 @@
+package com.cabaggregator.rideservice.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import org.bson.types.ObjectId;
+
+import java.util.UUID;
+
+@AllArgsConstructor
+public class RateAddingDto {
+    private ObjectId rideId;
+    private UUID driverId;
+    private UUID passengerId;
+}

--- a/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/producer/RateProducer.java
+++ b/ride-service/src/main/java/com/cabaggregator/rideservice/kafka/producer/RateProducer.java
@@ -1,0 +1,30 @@
+package com.cabaggregator.rideservice.kafka.producer;
+
+import com.cabaggregator.rideservice.kafka.config.KafkaTopicConfig;
+import com.cabaggregator.rideservice.kafka.dto.RateAddingDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RateProducer {
+    private final KafkaTopicConfig topicConfig;
+
+    private final KafkaTemplate<String, RateAddingDto> kafkaTemplate;
+
+    public void sendMessage(RateAddingDto rate) {
+        Message<RateAddingDto> message = MessageBuilder
+                .withPayload(rate)
+                .setHeader(
+                        KafkaHeaders.TOPIC,
+                        topicConfig.getRate()
+                                .getName())
+                .build();
+
+        kafkaTemplate.send(message);
+    }
+}

--- a/ride-service/src/main/resources/application.yml
+++ b/ride-service/src/main/resources/application.yml
@@ -23,9 +23,9 @@ app:
   kafka:
     topics:
       rate:
-        name: ${KAFKA_TOPIC_RATE_NAME:rate-topic}
-        partitions: ${KAFKA_TOPIC_RATE_PARTITIONS:1}
-        replicas: ${KAFKA_TOPIC_RATE_REPLICAS:1}
+        name: rating.creation.v1
+        partitions: 1
+        replicas: 1
 services:
   open-route:
     name: open-route-api

--- a/ride-service/src/main/resources/application.yml
+++ b/ride-service/src/main/resources/application.yml
@@ -20,6 +20,12 @@ mongock:
 app:
   open-route:
     api-key: ${OPENROUTE_API_KEY}
+  kafka:
+    topics:
+      rate:
+        name: ${KAFKA_TOPIC_RATE_NAME:rate-topic}
+        partitions: ${KAFKA_TOPIC_RATE_PARTITIONS:1}
+        replicas: ${KAFKA_TOPIC_RATE_REPLICAS:1}
 services:
   open-route:
     name: open-route-api


### PR DESCRIPTION
**This pull request adds integration of ride with rating services using kafka.**

_Main logic:_
When a ride is completed, the Ride Service sends a message to Kafka containing the necessary data about the ride and its participants. The Rating Service listens to this message and automatically creates empty rating entries for both the passenger and the driver. These entries include fields for the rating and feedback options but are initially left blank.

The same Kafka message is also consumed by the frontend, which informs users that they can now rate the other participant of the ride. This automated creation of DriverRate and PassengerRate objects ensures a seamless rating process by eliminating the need for additional calls to the Ride Service for validation.

In the future, a scheduler will be implemented to periodically clean up old rating entries that remain incomplete (i.e., without feedback or a rating). This will prevent users from rating rides they took too long ago, ensuring the feedback remains relevant and reliable.